### PR TITLE
Templates for github issues

### DIFF
--- a/.github/issue_template/bug-report.md
+++ b/.github/issue_template/bug-report.md
@@ -1,0 +1,33 @@
+---
+name: Bug Report
+about: Report an issue with the docker image.
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+Please attempt to verify if the issue is with the image, or the dependency itself. Issues with dependencies themselves should be directed to the relevant project bug trackers.
+
+**To Reproduce**
+Steps to reproduce the image, or a link to a repository showing the issue.
+
+```bash
+docker pull cardboardci/<image>:<digest>
+
+# commands to run in image to reproduce
+```
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Docker Image:**
+ - Tag: [e.g. `1.2.3-20190102`]
+ - Digest: [e.g. `sha256:e0e4bbf87f0f8a79dca2658f8a80be683f510fdcda1877d36a2d71cab9ce7c0d`]
+ - Dependency Versions: [e.g. relevant version of dependencies]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/issue_template/dependency-request.md
+++ b/.github/issue_template/dependency-request.md
@@ -1,0 +1,20 @@
+---
+name: Dependency request
+about: Suggest a dependency for this image
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm trying to do X, and have tried to solve it by doing Y [...]
+
+**Describe the solution you'd like**
+A clear and concise description of how you'd like to solve the problem with the image.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# images
-Dockerfiles for CardboardCI convenience images
+# cardboardci-dockerfiles
+
+Dockerfiles for [CardboardCI's Docker images](https://hub.docker.com/r/cardboardci).


### PR DESCRIPTION
Github issue templates for requesting dependencies added to an image, as well as bugs encountered with use of image.

The templates are pulled from the previous `docker-` repositories.