### PR TITLE
Scripts for automatic upgrading of dependency lists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+.DEFAULT_GOAL:=help
+
+DIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
+
+.PHONY: help
+help: ## This help text.
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Docker
+
+.PHONY: apt
+
+apt-% : ; ## Upgrades the apt deps
+	docker run \
+		--rm \
+		--user=root \
+		--entrypoint="" \
+		-v "$(DIR)":/workspace \
+		--workdir=/workspace \
+		cardboardci/ci-core:latest bash tools/apt.bash $*
+
+npm-% : ; ## Upgrades the npm deps
+	docker run \
+		--rm \
+		--user=root \
+		--entrypoint="" \
+		-v "$(DIR)":/workspace \
+		--workdir=/workspace \
+		node:latest bash tools/npm.bash $*
+
+gem-% : ; ## Upgrades the gem deps
+	docker run \
+		--rm \
+		--user=root \
+		--entrypoint="" \
+		-v "$(DIR)":/workspace \
+		--workdir=/workspace \
+		ruby:latest bash tools/gem.bash $*
+
+luarocks-% : ; ## Upgrades the lua deps
+	docker run \
+		--rm \
+		--user=root \
+		--entrypoint="" \
+		-v "$(DIR)":/workspace \
+		--workdir=/workspace \
+		ubuntu:latest bash tools/luarocks.bash $*

--- a/tools/apt.bash
+++ b/tools/apt.bash
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+if [ "$@" == "core" ]; then
+    CONTAINER="core"
+else
+    CONTAINER="definitions/$@"
+fi
+
+# Update package status
+apt-get update
+
+# Emit the current versions
+echo "Current versions"
+cat ${CONTAINER}/provision/pkglist
+
+mv ${CONTAINER}/provision/pkglist ${CONTAINER}/provision/pkglist.bak
+touch ${CONTAINER}/provision/pkglist
+while read line; do
+    echo "Working with ${line}"
+    input=(${line//=/ })
+    echo "Determining version for ${input}"
+    version=$(apt-cache policy ${input} | grep 'Candidate: ' | awk -F"[ ',]+" '/Candidate:/{print $3}')
+    echo "Found version as ${version}"
+    echo "${input}=${version}" >> ${CONTAINER}/provision/pkglist
+done <${CONTAINER}/provision/pkglist.bak
+
+#
+rm ${CONTAINER}/provision/pkglist.bak
+cat ${CONTAINER}/provision/pkglist

--- a/tools/apt.bash
+++ b/tools/apt.bash
@@ -3,7 +3,7 @@ set -e
 if [ "$@" == "core" ]; then
     CONTAINER="core"
 else
-    CONTAINER="definitions/$@"
+    CONTAINER="images/$@"
 fi
 
 # Update package status

--- a/tools/gem.bash
+++ b/tools/gem.bash
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+CONTAINER="definitions/$@"
+
+# Emit the current versions
+echo "Current versions"
+cat ${CONTAINER}/provision/gemlist
+
+mv ${CONTAINER}/provision/gemlist ${CONTAINER}/provision/gemlist.bak
+touch ${CONTAINER}/provision/gemlist
+while read line; do
+    echo "Working with ${line}"
+    input=(${line//:/ })
+    echo "Determining version for ${input}"
+    version=$(gem list "^${input}$" -r | grep -o '\((.*)\)$' | tr -d '() ' | tr ',' "\n")
+    echo "Found version as ${version}"
+    echo "${input}:${version}" >> ${CONTAINER}/provision/gemlist
+done <${CONTAINER}/provision/gemlist.bak
+
+#
+rm ${CONTAINER}/provision/gemlist.bak
+cat ${CONTAINER}/provision/gemlist

--- a/tools/gem.bash
+++ b/tools/gem.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-CONTAINER="definitions/$@"
+CONTAINER="images/$@"
 
 # Emit the current versions
 echo "Current versions"

--- a/tools/github.bash
+++ b/tools/github.bash
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+result=$(curl -s https://api.github.com/repos/cli/cli/releases/latest \
+    | grep "browser_download_url.*linux_amd64.deb" \
+    | cut -d : -f 2,3 \
+    | tr -d \")

--- a/tools/luarocks.bash
+++ b/tools/luarocks.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-CONTAINER="definitions/$@"
+CONTAINER="images/$@"
 
 apt update -qq
 apt install -qq luarocks -y

--- a/tools/luarocks.bash
+++ b/tools/luarocks.bash
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+CONTAINER="definitions/$@"
+
+apt update -qq
+apt install -qq luarocks -y
+
+# Emit the current versions
+echo "Current versions"
+cat ${CONTAINER}/provision/lualist
+
+mv ${CONTAINER}/provision/lualist ${CONTAINER}/provision/lualist.bak
+touch ${CONTAINER}/provision/lualist
+while read line; do
+    echo "Working with ${line}"
+    input=(${line// / })
+    echo "Determining version for ${input}"
+    luarocks install "${input}"
+    version=$(luarocks show ${input} | egrep "${input} ([0-9]{1,}\.)+[0-9]{1,}" | awk -F' ' '{print $2}')
+    echo "Found version as ${version}"
+    echo "${input} ${version}" >> ${CONTAINER}/provision/lualist
+done <${CONTAINER}/provision/lualist.bak
+
+#
+rm ${CONTAINER}/provision/lualist.bak
+cat ${CONTAINER}/provision/lualist

--- a/tools/npm.bash
+++ b/tools/npm.bash
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+CONTAINER="definitions/$@"
+
+# Emit the current versions
+echo "Current versions"
+cat ${CONTAINER}/provision/nodelist
+
+mv ${CONTAINER}/provision/nodelist ${CONTAINER}/provision/nodelist.bak
+touch ${CONTAINER}/provision/nodelist
+while read line; do
+    echo "Working with ${line}"
+    input=(${line//@/ })
+    echo "Determining version for ${input}"
+    version=$(npm show ${input} version)
+    echo "Found version as ${version}"
+    echo "${input}@${version}" >> ${CONTAINER}/provision/nodelist
+done <${CONTAINER}/provision/nodelist.bak
+
+#
+rm ${CONTAINER}/provision/nodelist.bak
+cat ${CONTAINER}/provision/nodelist

--- a/tools/npm.bash
+++ b/tools/npm.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-CONTAINER="definitions/$@"
+CONTAINER="images/$@"
 
 # Emit the current versions
 echo "Current versions"


### PR DESCRIPTION
Scripts for retrieving the latest version of a dependency from the relevant package manager. This removes the need for manual lookup, and allows the process to be completed from a central makefile.

The usage style is intended to be `make <package>-<image>`, and will attempt to get the latest available version for that dependency.

For now, the dependencies of images will be list in txt-style files, that will be read in and installed on the fly. Long term is for each of the dependencies to be described in a yml or json format.