### PR TITLE
Generic icon that is used for the container images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# images
-Dockerfiles for CardboardCI convenience images
+# cardboardci-dockerfiles
+
+Dockerfiles for [CardboardCI's Docker images](https://hub.docker.com/r/cardboardci).

--- a/docs/icon/logo.svg
+++ b/docs/icon/logo.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="100"
+   height="100"
+   viewBox="0 0 100 100"
+   version="1.1"
+   id="svg3753"
+   sodipodi:docname="logo.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     id="namedview9"
+     showgrid="false"
+     inkscape:zoom="2.36"
+     inkscape:cx="50"
+     inkscape:cy="50"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3753" />
+  <metadata
+     id="metadata3759">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3757">
+    <style
+       id="style920">.cls-1{fill:none;}</style>
+  </defs>
+  <path
+     style="fill:#0088aa;stroke-width:1.26868391;fill-opacity:1"
+     id="path3741"
+     d="M 79.257454,91.19577 H 21.938315 A 11.951002,11.951002 0 0 1 10,79.257454 V 21.938315 A 11.951002,11.951002 0 0 1 21.938315,10 H 79.257454 A 11.951002,11.951002 0 0 1 91.19577,21.938315 V 79.257454 A 11.951002,11.951002 0 0 1 79.257454,91.19577 Z M 21.938315,14.770251 a 7.1807509,7.1807509 0 0 0 -7.168064,7.168064 v 57.319139 a 7.1807509,7.1807509 0 0 0 7.168064,7.168064 h 57.319139 a 7.1807509,7.1807509 0 0 0 7.168064,-7.168064 V 21.938315 a 7.1807509,7.1807509 0 0 0 -7.168064,-7.168064 z" />
+  <path
+     id="path926"
+     d="M 50.780872,74.605074 30.840581,62.498469 V 38.997412 L 50.780872,27.60296 70.721163,39.353488 V 62.854546 Z M 35.113501,60.362009 50.780872,69.591515 66.448244,60.362009 V 41.846025 L 50.780872,32.630762 35.113501,41.846025 Z"
+     style="fill:#0088aa;fill-opacity:1;stroke-width:0.99999994" />
+</svg>

--- a/docs/icon/logo.yml
+++ b/docs/icon/logo.yml
@@ -1,0 +1,11 @@
+---
+name: Object
+url: https://thenounproject.com/term/object/1656168/
+author:
+  name: Mehmet Arif Erşahin, TR
+  url: https://thenounproject.com/marifersahin
+license:
+  name: Public Domain
+tags:
+  - Object
+  - Disaster


### PR DESCRIPTION
Add in the generic icon that is used to represent container images, that is a placeholder for the time being.

All of the containers have an icon associated with them, so that they can be looked up in a visual manner. The ones used at the moment are placeholders, as they will later be replaced with images relevant to the internals of the container.