### PR TITLE
Include the wkhtmltopdf image into the repository

### DIFF
--- a/.github/workflows/wkhtmltopdf.build.yml
+++ b/.github/workflows/wkhtmltopdf.build.yml
@@ -1,0 +1,54 @@
+name: wkhtmltopdf-build
+on:
+  push:
+    paths:
+      - definitions/wkhtmltopdf/provision/*
+      - definitions/wkhtmltopdf/provision/*/*
+      - definitions/wkhtmltopdf/provision/*/*/*
+      - definitions/wkhtmltopdf/rootfs/*
+      - definitions/wkhtmltopdf/rootfs/*/*
+      - definitions/wkhtmltopdf/rootfs/*/*/*
+      - definitions/wkhtmltopdf/tests/*
+      - definitions/wkhtmltopdf/tests/*/*
+      - definitions/wkhtmltopdf/Dockerfile
+      - .github/workflows/wkhtmltopdf.build.yml
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set versions
+        id: version
+        run: |
+          echo ::set-output name=docker_version::0.0.1
+          echo ::set-output name=docker_path::definitions/wkhtmltopdf
+
+      - name: Set tag var
+        id: vars
+        run: |
+          echo ::set-output name=docker_image::docker.io/cardboardci/wkhtmltopdf
+          echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
+
+      - name: Hadolint
+        uses: docker://docker.io/cardboardci/hadolint:latest
+        with:
+          args: "hadolint definitions/wkhtmltopdf/Dockerfile"
+
+      - name: Build
+        run: |
+          docker build ${{ steps.version.outputs.docker_path }}/. \
+            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+            --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
+
+      - name: Tests
+        uses: docker://gcr.io/gcp-runtimes/container-structure-test
+        with:
+          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+
+      - name: Deploy to DockerHub
+        if: github.ref == 'refs/heads/master'
+        run: |
+          echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+          docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/wkhtmltopdf.build.yml
+++ b/.github/workflows/wkhtmltopdf.build.yml
@@ -2,15 +2,15 @@ name: wkhtmltopdf-build
 on:
   push:
     paths:
-      - definitions/wkhtmltopdf/provision/*
-      - definitions/wkhtmltopdf/provision/*/*
-      - definitions/wkhtmltopdf/provision/*/*/*
-      - definitions/wkhtmltopdf/rootfs/*
-      - definitions/wkhtmltopdf/rootfs/*/*
-      - definitions/wkhtmltopdf/rootfs/*/*/*
-      - definitions/wkhtmltopdf/tests/*
-      - definitions/wkhtmltopdf/tests/*/*
-      - definitions/wkhtmltopdf/Dockerfile
+      - images/wkhtmltopdf/provision/*
+      - images/wkhtmltopdf/provision/*/*
+      - images/wkhtmltopdf/provision/*/*/*
+      - images/wkhtmltopdf/rootfs/*
+      - images/wkhtmltopdf/rootfs/*/*
+      - images/wkhtmltopdf/rootfs/*/*/*
+      - images/wkhtmltopdf/tests/*
+      - images/wkhtmltopdf/tests/*/*
+      - images/wkhtmltopdf/Dockerfile
       - .github/workflows/wkhtmltopdf.build.yml
 
 jobs:
@@ -23,7 +23,7 @@ jobs:
         id: version
         run: |
           echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::definitions/wkhtmltopdf
+          echo ::set-output name=docker_path::images/wkhtmltopdf
 
       - name: Set tag var
         id: vars
@@ -34,7 +34,7 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint definitions/wkhtmltopdf/Dockerfile"
+          args: "hadolint images/wkhtmltopdf/Dockerfile"
 
       - name: Build
         run: |

--- a/images/wkhtmltopdf/.dockerignore
+++ b/images/wkhtmltopdf/.dockerignore
@@ -1,0 +1,3 @@
+*
+!rootfs/
+!provision/

--- a/images/wkhtmltopdf/Dockerfile
+++ b/images/wkhtmltopdf/Dockerfile
@@ -1,0 +1,54 @@
+FROM cardboardci/ci-core@sha256:5b93f4c8cc1ddaa809f9c27d0a865a974ccb43e5e3d38334df1b0d77ea1843fb
+USER root
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+COPY provision/pkglist /cardboardci/pkglist
+RUN apt-get update \
+    && xargs -a /cardboardci/pkglist apt-get install --no-install-recommends -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY provision/deblist /cardboardci/deblist
+RUN mkdir -p /tmp/deb \
+    && xargs -a /cardboardci/deblist wget --directory-prefix=/tmp/deb \
+    && dpkg -i /tmp/deb/*.deb \
+    && rm -rf /tmp/zip
+
+USER cardboardci
+
+##
+## Image Metadata
+##
+ARG VCS_REF
+ARG IMAGE_NAME=cardboardci/wkhtmltopdf:${VERSION}
+LABEL maintainer="CardboardCI" \
+    \
+    readme.md="https://github.com/cardboardci/docker-wkhtmltopdf/blob/master/README.md" \
+    description="wkhtmltopdf is a command line tools to render HTML into PDF" \
+    \
+    org.label-schema.schema-version="1.0" \
+    \
+    org.label-schema.name="wkhtmltopdf" \
+    org.label-schema.version=${VERSION} \
+    org.label-schema.release="CardboardCI version:${version}" \
+    org.label-schema.vendor="CardboardCI" \
+    org.label-schema.architecture="amd64" \
+    org.label-schema.usage="https://github.com/cardboardci/docker-wkhtmltopdf/blob/master/README.md#Usage" \
+    \
+    org.label-schema.summary="Render HTML into PDFs" \
+    org.label-schema.description="wkhtmltopdf is a command line tools to render HTML into PDF" \
+    \
+    org.label-schema.url="https://github.com/cardboardci/docker-wkhtmltopdf/blob/master/README.md" \
+    org.label-schema.changelog-url="https://gitlab.com/cardboardci/images/wkhtmltopdf/releases" \
+    org.label-schema.authoritative-source-url="https://cloud.docker.com/u/cardboardci/repository/docker/cardboardci/wkhtmltopdf" \
+    org.label-schema.distribution-scope="public" \
+    \
+    org.label-schema.docker.cmd="docker run ${IMAGE_NAME} pwsh -c '$psversiontable'" \
+    org.label-schema.docker.cmd.devel="docker run ${IMAGE_NAME}" \
+    org.label-schema.docker.cmd.test="docker run ${IMAGE_NAME} pwsh -c Invoke-Pester" \
+    org.label-schema.docker.cmd.help="docker run ${IMAGE_NAME} pwsh -c Get-Help" \
+    \
+    org.label-schema.vcs-type="git" \
+    org.label-schema.vcs-url="https://github.com/cardboardci/docker-wkhtmltopdf" \
+    org.label-schema.vcs-ref=${VCS_REF}

--- a/images/wkhtmltopdf/README.md
+++ b/images/wkhtmltopdf/README.md
@@ -1,0 +1,71 @@
+# Docker image for WkHtmlToPDF
+
+wkhtmltopdf and wkhtmltoimage are open source (LGPLv3) command line tools to render HTML into PDF and various image formats using the Qt WebKit rendering engine. These run entirely "headless" and do not require a display or display service.
+
+You can see the cli reference [here](https://github.com/wkhtmltopdf/wkhtmltopdf).
+
+## Usage
+
+You can run awscli to manage your AWS services.
+
+```bash
+aws iam list-users
+aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
+aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```
+
+### Pull latest image
+
+```bash
+docker pull cardboardci/wkhtmltopdf
+```
+
+### Test interactively
+
+```bash
+docker run -it cardboardci/wkhtmltopdf /bin/bash
+```
+
+### Run basic AWS command
+
+```bash
+docker run -it -v "$(pwd)":/workspace cardboardci/wkhtmltopdf aws s3 cp file.txt s3://bucket/file.txt
+```
+
+### Run AWS CLI with custom profile
+
+```bash
+docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/wkhtmltopdf aws s3 cp file.txt s3://bucket/file.txt
+```
+
+### Continuous Integration Services
+
+For each of the following services, you can see an example of this image in that environment:
+
+* [CircleCI](usages/circleci)
+* [GitHub Actions](usages/github)
+* [GitLabCI](usages/gitlabci)
+* [JenkinsFile](usages/jenkins)
+* [TravisCI](usages/travisci)
+* [Codeship](usages/codeship)
+
+## Tagging Strategy
+
+Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
+
+* `latest`: The most-recently released version of an image. (`cardboardci/wkhtmltopdf:latest`)
+* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/wkhtmltopdf:1.0.0`)
+* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
+
+We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
+
+```bash
+docker pull cardboardci/wkhtmltopdf:latest
+docker inspect --format='{{index .RepoDigests 0}}' cardboardci/wkhtmltopdf:latest
+```
+
+## Fundamentals
+
+All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
+
+By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.

--- a/images/wkhtmltopdf/provision/deblist
+++ b/images/wkhtmltopdf/provision/deblist
@@ -1,0 +1,2 @@
+http://security.ubuntu.com/ubuntu/pool/main/o/openssl1.0/libssl1.0.0_1.0.2n-1ubuntu5.3_amd64.deb
+https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.bionic_amd64.deb

--- a/images/wkhtmltopdf/provision/pkglist
+++ b/images/wkhtmltopdf/provision/pkglist
@@ -1,4 +1,4 @@
-openssl=1.1.1f-1ubuntu1
+openssl=1.1.1f-1ubuntu2
 build-essential=12.8ubuntu1
 curl=7.68.0-1ubuntu2
 xz-utils=5.2.4-1

--- a/images/wkhtmltopdf/provision/pkglist
+++ b/images/wkhtmltopdf/provision/pkglist
@@ -1,0 +1,16 @@
+openssl=1.1.1f-1ubuntu1
+build-essential=12.8ubuntu1
+curl=7.68.0-1ubuntu2
+xz-utils=5.2.4-1
+ca-certificates=20190110ubuntu1
+xfonts-100dpi=1:1.0.4+nmu1
+xfonts-75dpi=1:1.0.4+nmu1
+xfonts-base=1:1.0.5
+fonts-roboto=2:0~20170802-3
+fonts-inconsolata=001.010-5
+ttf-mscorefonts-installer=3.7ubuntu6
+fontconfig=2.13.1-2ubuntu3
+xorg=1:7.7+19ubuntu14
+wget=1.20.3-1ubuntu1
+zlib1g=1:1.2.11.dfsg-2ubuntu1
+libpng16-16=1.6.37-2

--- a/images/wkhtmltopdf/tests/assets/basic.html
+++ b/images/wkhtmltopdf/tests/assets/basic.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <h1>My First Heading</h1>
+    <p>My first paragraph.</p>
+  </body>
+</html>

--- a/images/wkhtmltopdf/tests/tests.yaml
+++ b/images/wkhtmltopdf/tests/tests.yaml
@@ -1,0 +1,11 @@
+schemaVersion: "2.0.0"
+
+metadataTest:
+  labels:
+    - key: 'org.label-schema.vendor'
+      value: CardboardCI
+  exposedPorts: []
+  volumes: []
+  entrypoint: ["/bin/bash"]
+  cmd: []
+  workdir: "/cardboardci/workspace" 


### PR DESCRIPTION
A container responsible for converting from HTML files into PDFs.

This container is modeled after the original repository `docker-wkhtmltopdf`.