### PR TITLE
Include the github image into the repository

### DIFF
--- a/.github/workflows/github.build.yml
+++ b/.github/workflows/github.build.yml
@@ -1,0 +1,54 @@
+name: github-build
+on:
+  push:
+    paths:
+      - definitions/github/provision/*
+      - definitions/github/provision/*/*
+      - definitions/github/provision/*/*/*
+      - definitions/github/rootfs/*
+      - definitions/github/rootfs/*/*
+      - definitions/github/rootfs/*/*/*
+      - definitions/github/tests/*
+      - definitions/github/tests/*/*
+      - definitions/github/Dockerfile
+      - .github/workflows/github.build.yml
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set versions
+        id: version
+        run: |
+          echo ::set-output name=docker_version::0.0.1
+          echo ::set-output name=docker_path::definitions/github
+
+      - name: Set tag var
+        id: vars
+        run: |
+          echo ::set-output name=docker_image::docker.io/cardboardci/github
+          echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
+
+      - name: Hadolint
+        uses: docker://docker.io/cardboardci/hadolint:latest
+        with:
+          args: "hadolint definitions/github/Dockerfile"
+
+      - name: Build
+        run: |
+          docker build ${{ steps.version.outputs.docker_path }}/. \
+            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+            --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
+
+      - name: Tests
+        uses: docker://gcr.io/gcp-runtimes/container-structure-test
+        with:
+          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+
+      - name: Deploy to DockerHub
+        if: github.ref == 'refs/heads/master'
+        run: |
+          echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+          docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/github.build.yml
+++ b/.github/workflows/github.build.yml
@@ -2,15 +2,15 @@ name: github-build
 on:
   push:
     paths:
-      - definitions/github/provision/*
-      - definitions/github/provision/*/*
-      - definitions/github/provision/*/*/*
-      - definitions/github/rootfs/*
-      - definitions/github/rootfs/*/*
-      - definitions/github/rootfs/*/*/*
-      - definitions/github/tests/*
-      - definitions/github/tests/*/*
-      - definitions/github/Dockerfile
+      - images/github/provision/*
+      - images/github/provision/*/*
+      - images/github/provision/*/*/*
+      - images/github/rootfs/*
+      - images/github/rootfs/*/*
+      - images/github/rootfs/*/*/*
+      - images/github/tests/*
+      - images/github/tests/*/*
+      - images/github/Dockerfile
       - .github/workflows/github.build.yml
 
 jobs:
@@ -23,7 +23,7 @@ jobs:
         id: version
         run: |
           echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::definitions/github
+          echo ::set-output name=docker_path::images/github
 
       - name: Set tag var
         id: vars
@@ -34,7 +34,7 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint definitions/github/Dockerfile"
+          args: "hadolint images/github/Dockerfile"
 
       - name: Build
         run: |

--- a/images/github/.dockerignore
+++ b/images/github/.dockerignore
@@ -1,0 +1,3 @@
+*
+!rootfs/
+!provision/

--- a/images/github/Dockerfile
+++ b/images/github/Dockerfile
@@ -1,0 +1,42 @@
+FROM cardboardci/ci-core@sha256:5b93f4c8cc1ddaa809f9c27d0a865a974ccb43e5e3d38334df1b0d77ea1843fb
+USER root
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+COPY provision/pkglist /cardboardci/pkglist
+RUN apt-get update \
+    && xargs -a /cardboardci/pkglist apt-get install --no-install-recommends -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY provision/deblist /cardboardci/deblist
+RUN mkdir -p /tmp/deb \
+    && xargs -a /cardboardci/deblist wget --directory-prefix=/tmp/deb \
+    && dpkg -i /tmp/deb/*.deb \
+    && rm -rf /tmp/zip
+
+USER cardboardci
+
+##
+## Image Metadata
+##
+ARG build_date
+ARG version
+ARG vcs_ref
+LABEL maintainer="CardboardCI"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="github"
+LABEL org.label-schema.version="${version}"
+LABEL org.label-schema.build-date="${build_date}"
+LABEL org.label-schema.release="CardboardCI version:${version} build-date:${build_date}"
+LABEL org.label-schema.vendor="cardboardci"
+LABEL org.label-schema.architecture="amd64"
+LABEL org.label-schema.summary="GitHub CLI"
+LABEL org.label-schema.description="A command-line tool that makes git easier to use with GitHub"
+LABEL org.label-schema.url="https://gitlab.com/cardboardci/images/github"
+LABEL org.label-schema.changelog-url="https://gitlab.com/cardboardci/images/github/releases"
+LABEL org.label-schema.authoritative-source-url="https://cloud.docker.com/u/cardboardci/repository/docker/cardboardci/github"
+LABEL org.label-schema.distribution-scope="public"
+LABEL org.label-schema.vcs-type="git"
+LABEL org.label-schema.vcs-url="https://gitlab.com/cardboardci/images/github"
+LABEL org.label-schema.vcs-ref="${vcs_ref}"

--- a/images/github/README.md
+++ b/images/github/README.md
@@ -1,0 +1,71 @@
+# Docker image for GitHubCLI
+
+`hub` is an extension to command-line git that helps you do everyday GitHub tasks without ever leaving the terminal. `hub` can be safely aliased as git so you can type `$ git <command>`in the shell and get all the usual hub features.
+
+You can see the source repository [here](https://github.com/dropbox/dbxcli).
+
+## Usage
+
+You can run awscli to manage your AWS services.
+
+```bash
+aws iam list-users
+aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
+aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```
+
+### Pull latest image
+
+```bash
+docker pull cardboardci/awscli
+```
+
+### Test interactively
+
+```bash
+docker run -it cardboardci/awscli /bin/bash
+```
+
+### Run basic AWS command
+
+```bash
+docker run -it -v "$(pwd)":/workspace cardboardci/awscli aws s3 cp file.txt s3://bucket/file.txt
+```
+
+### Run AWS CLI with custom profile
+
+```bash
+docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/awscli aws s3 cp file.txt s3://bucket/file.txt
+```
+
+### Continuous Integration Services
+
+For each of the following services, you can see an example of this image in that environment:
+
+* [CircleCI](usages/circleci)
+* [GitHub Actions](usages/github)
+* [GitLabCI](usages/gitlabci)
+* [JenkinsFile](usages/jenkins)
+* [TravisCI](usages/travisci)
+* [Codeship](usages/codeship)
+
+## Tagging Strategy
+
+Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
+
+* `latest`: The most-recently released version of an image. (`cardboardci/awscli:latest`)
+* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/awscli:1.0.0`)
+* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
+
+We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
+
+```bash
+docker pull cardboardci/awscli:latest
+docker inspect --format='{{index .RepoDigests 0}}' cardboardci/awscli:latest
+```
+
+## Fundamentals
+
+All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
+
+By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.

--- a/images/github/provision/deblist
+++ b/images/github/provision/deblist
@@ -1,0 +1,1 @@
+https://github.com/cli/cli/releases/download/v0.6.4/gh_0.6.4_linux_amd64.deb

--- a/images/github/provision/pkglist
+++ b/images/github/provision/pkglist
@@ -1,0 +1,5 @@
+ca-certificates=20190110ubuntu1
+git=1:2.25.1-1ubuntu2
+openssh-client=1:8.2p1-4
+vim-nox=2:8.1.2269-1ubuntu5
+wget=1.20.3-1ubuntu1

--- a/images/github/provision/pkglist
+++ b/images/github/provision/pkglist
@@ -1,5 +1,4 @@
 ca-certificates=20190110ubuntu1
-git=1:2.25.1-1ubuntu2
 openssh-client=1:8.2p1-4
 vim-nox=2:8.1.2269-1ubuntu5
 wget=1.20.3-1ubuntu1

--- a/images/github/tests/tests.yaml
+++ b/images/github/tests/tests.yaml
@@ -1,0 +1,11 @@
+schemaVersion: "2.0.0"
+
+metadataTest:
+  labels:
+    - key: 'org.label-schema.vendor'
+      value: cardboardci
+  exposedPorts: []
+  volumes: []
+  entrypoint: ["/bin/bash"]
+  cmd: []
+  workdir: "/cardboardci/workspace" 


### PR DESCRIPTION
A container responsible for the GithubCLI, which can be useful when working in github actions.

This container is modeled after the original repository `docker-github`.