### PR TITLE
Include the shellcheck image into the repository

### DIFF
--- a/.github/workflows/shellcheck.build.yml
+++ b/.github/workflows/shellcheck.build.yml
@@ -1,0 +1,54 @@
+name: shellcheck-build
+on:
+  push:
+    paths:
+      - definitions/shellcheck/provision/*
+      - definitions/shellcheck/provision/*/*
+      - definitions/shellcheck/provision/*/*/*
+      - definitions/shellcheck/rootfs/*
+      - definitions/shellcheck/rootfs/*/*
+      - definitions/shellcheck/rootfs/*/*/*
+      - definitions/shellcheck/tests/*
+      - definitions/shellcheck/tests/*/*
+      - definitions/shellcheck/Dockerfile
+      - .github/workflows/shellcheck.build.yml
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set versions
+        id: version
+        run: |
+          echo ::set-output name=docker_version::0.0.1
+          echo ::set-output name=docker_path::definitions/shellcheck
+
+      - name: Set tag var
+        id: vars
+        run: |
+          echo ::set-output name=docker_image::docker.io/cardboardci/shellcheck
+          echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
+
+      - name: Hadolint
+        uses: docker://docker.io/cardboardci/hadolint:latest
+        with:
+          args: "hadolint definitions/shellcheck/Dockerfile"
+
+      - name: Build
+        run: |
+          docker build ${{ steps.version.outputs.docker_path }}/. \
+            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+            --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
+
+      - name: Tests
+        uses: docker://gcr.io/gcp-runtimes/container-structure-test
+        with:
+          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+
+      - name: Deploy to DockerHub
+        if: github.ref == 'refs/heads/master'
+        run: |
+          echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+          docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/shellcheck.build.yml
+++ b/.github/workflows/shellcheck.build.yml
@@ -2,15 +2,15 @@ name: shellcheck-build
 on:
   push:
     paths:
-      - definitions/shellcheck/provision/*
-      - definitions/shellcheck/provision/*/*
-      - definitions/shellcheck/provision/*/*/*
-      - definitions/shellcheck/rootfs/*
-      - definitions/shellcheck/rootfs/*/*
-      - definitions/shellcheck/rootfs/*/*/*
-      - definitions/shellcheck/tests/*
-      - definitions/shellcheck/tests/*/*
-      - definitions/shellcheck/Dockerfile
+      - images/shellcheck/provision/*
+      - images/shellcheck/provision/*/*
+      - images/shellcheck/provision/*/*/*
+      - images/shellcheck/rootfs/*
+      - images/shellcheck/rootfs/*/*
+      - images/shellcheck/rootfs/*/*/*
+      - images/shellcheck/tests/*
+      - images/shellcheck/tests/*/*
+      - images/shellcheck/Dockerfile
       - .github/workflows/shellcheck.build.yml
 
 jobs:
@@ -23,7 +23,7 @@ jobs:
         id: version
         run: |
           echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::definitions/shellcheck
+          echo ::set-output name=docker_path::images/shellcheck
 
       - name: Set tag var
         id: vars
@@ -34,7 +34,7 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint definitions/shellcheck/Dockerfile"
+          args: "hadolint images/shellcheck/Dockerfile"
 
       - name: Build
         run: |

--- a/images/shellcheck/.dockerignore
+++ b/images/shellcheck/.dockerignore
@@ -1,0 +1,3 @@
+*
+!rootfs/
+!provision/

--- a/images/shellcheck/Dockerfile
+++ b/images/shellcheck/Dockerfile
@@ -1,0 +1,36 @@
+FROM cardboardci/ci-core@sha256:5b93f4c8cc1ddaa809f9c27d0a865a974ccb43e5e3d38334df1b0d77ea1843fb
+USER root
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+COPY provision/pkglist /cardboardci/pkglist
+RUN apt-get update \
+    && xargs -a /cardboardci/pkglist apt-get install --no-install-recommends -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+USER cardboardci
+
+##
+## Image Metadata
+##
+ARG build_date
+ARG version
+ARG vcs_ref
+LABEL maintainer="CardboardCI"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="shellcheck"
+LABEL org.label-schema.version="${version}"
+LABEL org.label-schema.build-date="${build_date}"
+LABEL org.label-schema.release="CardboardCI version:${version} build-date:${build_date}"
+LABEL org.label-schema.vendor="cardboardci"
+LABEL org.label-schema.architecture="amd64"
+LABEL org.label-schema.summary="Shell script static anaylsis"
+LABEL org.label-schema.description="ShellCheck is a static anaylsis tool that automatically finds bugs in your shell scripts"
+LABEL org.label-schema.url="https://gitlab.com/cardboardci/images/shellcheck"
+LABEL org.label-schema.changelog-url="https://gitlab.com/cardboardci/images/shellcheck/releases"
+LABEL org.label-schema.authoritative-source-url="https://cloud.docker.com/u/cardboardci/repository/docker/cardboardci/shellcheck"
+LABEL org.label-schema.distribution-scope="public"
+LABEL org.label-schema.vcs-type="git"
+LABEL org.label-schema.vcs-url="https://gitlab.com/cardboardci/images/shellcheck"
+LABEL org.label-schema.vcs-ref="${vcs_ref}"

--- a/images/shellcheck/README.md
+++ b/images/shellcheck/README.md
@@ -1,0 +1,77 @@
+# Docker image for Shellcheck
+
+ShellCheck is a GPLv3 tool that gives warnings and suggestions for bash/sh shell scripts:
+
+The goals of ShellCheck are:
+
+* To point out and clarify typical beginner's syntax issues that cause a shell to give cryptic error messages.
+* To point out and clarify typical intermediate level semantic problems that cause a shell to behave strangely and counter-intuitively.
+* To point out subtle caveats, corner cases and pitfalls that may cause an advanced user's otherwise working script to fail under future circumstances.
+
+You can see the cli reference [here](https://github.com/koalaman/shellcheck).
+
+## Usage
+
+You can run awscli to manage your AWS services.
+
+```bash
+aws iam list-users
+aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
+aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```
+
+### Pull latest image
+
+```bash
+docker pull cardboardci/shellcheck
+```
+
+### Test interactively
+
+```bash
+docker run -it cardboardci/shellcheck /bin/bash
+```
+
+### Run basic AWS command
+
+```bash
+docker run -it -v "$(pwd)":/workspace cardboardci/shellcheck aws s3 cp file.txt s3://bucket/file.txt
+```
+
+### Run AWS CLI with custom profile
+
+```bash
+docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/shellcheck aws s3 cp file.txt s3://bucket/file.txt
+```
+
+### Continuous Integration Services
+
+For each of the following services, you can see an example of this image in that environment:
+
+* [CircleCI](usages/circleci)
+* [GitHub Actions](usages/github)
+* [GitLabCI](usages/gitlabci)
+* [JenkinsFile](usages/jenkins)
+* [TravisCI](usages/travisci)
+* [Codeship](usages/codeship)
+
+## Tagging Strategy
+
+Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
+
+* `latest`: The most-recently released version of an image. (`cardboardci/shellcheck:latest`)
+* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/shellcheck:1.0.0`)
+* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
+
+We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
+
+```bash
+docker pull cardboardci/shellcheck:latest
+docker inspect --format='{{index .RepoDigests 0}}' cardboardci/shellcheck:latest
+```
+
+## Fundamentals
+
+All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
+
+By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.

--- a/images/shellcheck/provision/pkglist
+++ b/images/shellcheck/provision/pkglist
@@ -1,0 +1,1 @@
+shellcheck=0.7.0-2build2

--- a/images/shellcheck/tests/tests.yaml
+++ b/images/shellcheck/tests/tests.yaml
@@ -1,0 +1,11 @@
+schemaVersion: "2.0.0"
+
+metadataTest:
+  labels:
+    - key: 'org.label-schema.vendor'
+      value: cardboardci
+  exposedPorts: []
+  volumes: []
+  entrypoint: ["/bin/bash"]
+  cmd: []
+  workdir: "/cardboardci/workspace" 


### PR DESCRIPTION
A container responsible for the sh/bash linting tool `shellcheck`. Intented to be a lightweight image for assisting in bash/shell linting.

This container is modeled after the original repository `docker-shellcheck`.