### PR TITLE
Include the netlify image into the repository

### DIFF
--- a/.github/workflows/netlify.build.yml
+++ b/.github/workflows/netlify.build.yml
@@ -2,15 +2,15 @@ name: netlify-build
 on:
   push:
     paths:
-      - definitions/netlify/provision/*
-      - definitions/netlify/provision/*/*
-      - definitions/netlify/provision/*/*/*
-      - definitions/netlify/rootfs/*
-      - definitions/netlify/rootfs/*/*
-      - definitions/netlify/rootfs/*/*/*
-      - definitions/netlify/tests/*
-      - definitions/netlify/tests/*/*
-      - definitions/netlify/Dockerfile
+      - images/netlify/provision/*
+      - images/netlify/provision/*/*
+      - images/netlify/provision/*/*/*
+      - images/netlify/rootfs/*
+      - images/netlify/rootfs/*/*
+      - images/netlify/rootfs/*/*/*
+      - images/netlify/tests/*
+      - images/netlify/tests/*/*
+      - images/netlify/Dockerfile
       - .github/workflows/netlify.build.yml
 
 jobs:
@@ -23,7 +23,7 @@ jobs:
         id: version
         run: |
           echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::definitions/netlify
+          echo ::set-output name=docker_path::images/netlify
 
       - name: Set tag var
         id: vars
@@ -34,7 +34,7 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint definitions/netlify/Dockerfile"
+          args: "hadolint images/netlify/Dockerfile"
 
       - name: Build
         run: |

--- a/.github/workflows/netlify.build.yml
+++ b/.github/workflows/netlify.build.yml
@@ -1,0 +1,54 @@
+name: netlify-build
+on:
+  push:
+    paths:
+      - definitions/netlify/provision/*
+      - definitions/netlify/provision/*/*
+      - definitions/netlify/provision/*/*/*
+      - definitions/netlify/rootfs/*
+      - definitions/netlify/rootfs/*/*
+      - definitions/netlify/rootfs/*/*/*
+      - definitions/netlify/tests/*
+      - definitions/netlify/tests/*/*
+      - definitions/netlify/Dockerfile
+      - .github/workflows/netlify.build.yml
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set versions
+        id: version
+        run: |
+          echo ::set-output name=docker_version::0.0.1
+          echo ::set-output name=docker_path::definitions/netlify
+
+      - name: Set tag var
+        id: vars
+        run: |
+          echo ::set-output name=docker_image::docker.io/cardboardci/netlify
+          echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
+
+      - name: Hadolint
+        uses: docker://docker.io/cardboardci/hadolint:latest
+        with:
+          args: "hadolint definitions/netlify/Dockerfile"
+
+      - name: Build
+        run: |
+          docker build ${{ steps.version.outputs.docker_path }}/. \
+            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+            --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
+
+      - name: Tests
+        uses: docker://gcr.io/gcp-runtimes/container-structure-test
+        with:
+          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+
+      - name: Deploy to DockerHub
+        if: github.ref == 'refs/heads/master'
+        run: |
+          echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+          docker push ${{ steps.vars.outputs.docker_image }}

--- a/images/netlify/.dockerignore
+++ b/images/netlify/.dockerignore
@@ -1,0 +1,3 @@
+*
+!rootfs/
+!provision/

--- a/images/netlify/Dockerfile
+++ b/images/netlify/Dockerfile
@@ -1,0 +1,39 @@
+FROM cardboardci/ci-core@sha256:b3e7917c28200c780e0e6a19057cb546fcafc4719640f6b8be459c390714f97c
+USER root
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+COPY provision/pkglist /cardboardci/pkglist
+RUN apt-get update \
+    && xargs -a /cardboardci/pkglist apt-get install --no-install-recommends -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY provision/nodelist /cardboardci/nodelist
+RUN ( xargs -a /cardboardci/nodelist npm install -g ) || true
+
+USER cardboardci
+
+##
+## Image Metadata
+##
+ARG build_date
+ARG version
+ARG vcs_ref
+LABEL maintainer="CardboardCI"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="netlify"
+LABEL org.label-schema.version="${version}"
+LABEL org.label-schema.build-date="${build_date}"
+LABEL org.label-schema.release="CardboardCI version:${version} build-date:${build_date}"
+LABEL org.label-schema.vendor="cardboardci"
+LABEL org.label-schema.architecture="amd64"
+LABEL org.label-schema.summary="Netlify CLI"
+LABEL org.label-schema.description="Netlify builds, deploys and hosts your netlify services"
+LABEL org.label-schema.url="https://gitlab.com/cardboardci/images/netlify"
+LABEL org.label-schema.changelog-url="https://gitlab.com/cardboardci/images/netlify/releases"
+LABEL org.label-schema.authoritative-source-url="https://cloud.docker.com/u/cardboardci/repository/docker/cardboardci/netlify"
+LABEL org.label-schema.distribution-scope="public"
+LABEL org.label-schema.vcs-type="git"
+LABEL org.label-schema.vcs-url="https://gitlab.com/cardboardci/images/netlify"
+LABEL org.label-schema.vcs-ref="${vcs_ref}"

--- a/images/netlify/README.md
+++ b/images/netlify/README.md
@@ -1,0 +1,71 @@
+# Docker image for Netlify
+
+The Netlify CLI facilitates the deployment of websites to Netlify, to improve the site building experience.
+
+You can see the cli reference [here](https://github.com/netlify/cli).
+
+## Usage
+
+You can run awscli to manage your AWS services.
+
+```bash
+aws iam list-users
+aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
+aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```
+
+### Pull latest image
+
+```bash
+docker pull cardboardci/netlify
+```
+
+### Test interactively
+
+```bash
+docker run -it cardboardci/netlify /bin/bash
+```
+
+### Run basic AWS command
+
+```bash
+docker run -it -v "$(pwd)":/workspace cardboardci/netlify aws s3 cp file.txt s3://bucket/file.txt
+```
+
+### Run AWS CLI with custom profile
+
+```bash
+docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/netlify aws s3 cp file.txt s3://bucket/file.txt
+```
+
+### Continuous Integration Services
+
+For each of the following services, you can see an example of this image in that environment:
+
+* [CircleCI](usages/circleci)
+* [GitHub Actions](usages/github)
+* [GitLabCI](usages/gitlabci)
+* [JenkinsFile](usages/jenkins)
+* [TravisCI](usages/travisci)
+* [Codeship](usages/codeship)
+
+## Tagging Strategy
+
+Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
+
+* `latest`: The most-recently released version of an image. (`cardboardci/netlify:latest`)
+* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/netlify:1.0.0`)
+* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
+
+We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
+
+```bash
+docker pull cardboardci/netlify:latest
+docker inspect --format='{{index .RepoDigests 0}}' cardboardci/netlify:latest
+```
+
+## Fundamentals
+
+All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
+
+By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.

--- a/images/netlify/provision/nodelist
+++ b/images/netlify/provision/nodelist
@@ -1,0 +1,1 @@
+netlify-cli@2.47.0

--- a/images/netlify/provision/pkglist
+++ b/images/netlify/provision/pkglist
@@ -1,0 +1,2 @@
+nodejs=10.19.0~dfsg-3ubuntu1
+npm=6.14.4+ds-1ubuntu2

--- a/images/netlify/tests/tests.yaml
+++ b/images/netlify/tests/tests.yaml
@@ -1,0 +1,11 @@
+schemaVersion: "2.0.0"
+
+metadataTest:
+  labels:
+    - key: 'org.label-schema.vendor'
+      value: cardboardci
+  exposedPorts: []
+  volumes: []
+  entrypoint: ["/bin/bash"]
+  cmd: []
+  workdir: "/cardboardci/workspace" 


### PR DESCRIPTION
A container responsible for the netlifycli to allow a lightweight mechanism for deploying compiled builds to netlify.

This container is modeled after the original repository `docker-netlify`.

I intend to adapt this to support a better deployment model, with zip & helper scripts.