### PR TITLE
stylelint - Deploy README to docker hub description

### DIFF
--- a/.github/workflows/stylelint.hub.yml
+++ b/.github/workflows/stylelint.hub.yml
@@ -1,0 +1,21 @@
+name: stylelint-hub
+on:
+  push:
+    branches:
+      - master
+    paths:
+    - definitions/stylelint/README.md
+    - .github/workflows/stylelint.hub.yml
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@v2.1.0
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+          DOCKERHUB_REPOSITORY: cardboardci/stylelint
+          README_FILEPATH: definitions/stylelint/README.md


### PR DESCRIPTION
When the README of the image changes, it should update the readme on Docker Hub. This allows for common stylelint commands to be listed alongside the image itself.

I expect to later revise this to have a common descriptor template for every image, that references back to the central website. The advantage to that model is a better 'How to use' this image model, rather than attempting to link to existing `yml` files in source (for CI providers).