### PR TITLE
surge - Deploy README to docker hub description

### DIFF
--- a/.github/workflows/surge.hub.yml
+++ b/.github/workflows/surge.hub.yml
@@ -1,0 +1,21 @@
+name: surge-hub
+on:
+  push:
+    branches:
+      - master
+    paths:
+    - definitions/surge/README.md
+    - .github/workflows/surge.hub.yml
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@v2.1.0
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+          DOCKERHUB_REPOSITORY: cardboardci/surge
+          README_FILEPATH: definitions/surge/README.md


### PR DESCRIPTION
When the README of the image changes, it should update the readme on Docker Hub. This allows for common surge commands to be listed alongside the image itself.

I expect to later revise this to have a common descriptor template for every image, that references back to the central website. The advantage to that model is a better 'How to use' this image model, rather than attempting to link to existing `yml` files in source (for CI providers).