### PR TITLE
cppcheck - Deploy README to docker hub description

### DIFF
--- a/.github/workflows/cppcheck.hub.yml
+++ b/.github/workflows/cppcheck.hub.yml
@@ -1,0 +1,21 @@
+name: cppcheck-hub
+on:
+  push:
+    branches:
+      - master
+    paths:
+    - definitions/cppcheck/README.md
+    - .github/workflows/cppcheck.hub.yml
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@v2.1.0
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+          DOCKERHUB_REPOSITORY: cardboardci/cppcheck
+          README_FILEPATH: definitions/cppcheck/README.md

--- a/images/cppcheck/.dockerignore
+++ b/images/cppcheck/.dockerignore
@@ -1,0 +1,3 @@
+*
+!rootfs/
+!provision/

--- a/images/cppcheck/Dockerfile
+++ b/images/cppcheck/Dockerfile
@@ -1,0 +1,36 @@
+FROM cardboardci/ci-core@sha256:b3e7917c28200c780e0e6a19057cb546fcafc4719640f6b8be459c390714f97c
+USER root
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+COPY provision/pkglist /cardboardci/pkglist
+RUN apt-get update \
+    && xargs -a /cardboardci/pkglist apt-get install --no-install-recommends -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+USER cardboardci
+
+##
+## Image Metadata
+##
+ARG build_date
+ARG version
+ARG vcs_ref
+LABEL maintainer="CardboardCI"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="cppcheck"
+LABEL org.label-schema.version="${version}"
+LABEL org.label-schema.build-date="${build_date}"
+LABEL org.label-schema.release="CardboardCI version:${version} build-date:${build_date}"
+LABEL org.label-schema.vendor="cardboardci"
+LABEL org.label-schema.architecture="amd64"
+LABEL org.label-schema.summary="C++ linter"
+LABEL org.label-schema.description="Static analysis of C/C++ code"
+LABEL org.label-schema.url="https://gitlab.com/cardboardci/images/cppcheck"
+LABEL org.label-schema.changelog-url="https://gitlab.com/cardboardci/images/cppcheck/releases"
+LABEL org.label-schema.authoritative-source-url="https://cloud.docker.com/u/cardboardci/repository/docker/cardboardci/cppcheck"
+LABEL org.label-schema.distribution-scope="public"
+LABEL org.label-schema.vcs-type="git"
+LABEL org.label-schema.vcs-url="https://gitlab.com/cardboardci/images/cppcheck"
+LABEL org.label-schema.vcs-ref="${vcs_ref}"

--- a/images/cppcheck/README.md
+++ b/images/cppcheck/README.md
@@ -1,0 +1,74 @@
+# Docker image for CppCheck
+
+Cppcheck is an analysis tool for C/C++ code. It provides unique code analysis
+to detect bugs and focuses on detecting undefined behaviour and dangerous
+coding constructs. The goal is to detect only real errors in the code (i.e. have
+very few false positives).
+
+You can see the source repository [here](https://github.com/danmar/cppcheck).
+
+## Usage
+
+You can run awscli to manage your AWS services.
+
+```bash
+aws iam list-users
+aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
+aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```
+
+### Pull latest image
+
+```bash
+docker pull cardboardci/awscli
+```
+
+### Test interactively
+
+```bash
+docker run -it cardboardci/awscli /bin/bash
+```
+
+### Run basic AWS command
+
+```bash
+docker run -it -v "$(pwd)":/workspace cardboardci/awscli aws s3 cp file.txt s3://bucket/file.txt
+```
+
+### Run AWS CLI with custom profile
+
+```bash
+docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/awscli aws s3 cp file.txt s3://bucket/file.txt
+```
+
+### Continuous Integration Services
+
+For each of the following services, you can see an example of this image in that environment:
+
+* [CircleCI](usages/circleci)
+* [GitHub Actions](usages/github)
+* [GitLabCI](usages/gitlabci)
+* [JenkinsFile](usages/jenkins)
+* [TravisCI](usages/travisci)
+* [Codeship](usages/codeship)
+
+## Tagging Strategy
+
+Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
+
+* `latest`: The most-recently released version of an image. (`cardboardci/awscli:latest`)
+* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/awscli:1.0.0`)
+* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
+
+We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
+
+```bash
+docker pull cardboardci/awscli:latest
+docker inspect --format='{{index .RepoDigests 0}}' cardboardci/awscli:latest
+```
+
+## Fundamentals
+
+All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
+
+By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.

--- a/images/cppcheck/provision/pkglist
+++ b/images/cppcheck/provision/pkglist
@@ -1,0 +1,6 @@
+build-essential=12.8ubuntu1
+libpcre3-dev=2:8.39-12build1
+curl=7.68.0-1ubuntu2
+python3=3.8.2-0ubuntu2
+python-pygments=2.3.1+dfsg-1ubuntu2
+cppcheck=1.90-4build1

--- a/images/cppcheck/tests/tests.yaml
+++ b/images/cppcheck/tests/tests.yaml
@@ -1,0 +1,11 @@
+schemaVersion: "2.0.0"
+
+metadataTest:
+  labels:
+    - key: 'org.label-schema.vendor'
+      value: cardboardci
+  exposedPorts: []
+  volumes: []
+  entrypoint: ["/bin/bash"]
+  cmd: []
+  workdir: "/cardboardci/workspace" 


### PR DESCRIPTION
When the README of the image changes, it should update the readme on Docker Hub. This allows for common cppcheck commands to be listed alongside the image itself.

I expect to later revise this to have a common descriptor template for every image, that references back to the central website. The advantage to that model is a better 'How to use' this image model, rather than attempting to link to existing `yml` files in source (for CI providers).