### PR TITLE
hugo - Deploy README to docker hub description

### DIFF
--- a/.github/workflows/hugo.hub.yml
+++ b/.github/workflows/hugo.hub.yml
@@ -1,0 +1,21 @@
+name: hugo-hub
+on:
+  push:
+    branches:
+      - master
+    paths:
+    - definitions/hugo/README.md
+    - .github/workflows/hugo.hub.yml
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@v2.1.0
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+          DOCKERHUB_REPOSITORY: cardboardci/hugo
+          README_FILEPATH: definitions/hugo/README.md


### PR DESCRIPTION
When the README of the image changes, it should update the readme on Docker Hub. This allows for common hugo commands to be listed alongside the image itself.

I expect to later revise this to have a common descriptor template for every image, that references back to the central website. The advantage to that model is a better 'How to use' this image model, rather than attempting to link to existing `yml` files in source (for CI providers).