### PR TITLE
cppcheck - scheduled task that raises PRs for new versions

### DIFF
--- a/.github/workflows/cppcheck.versions.yml
+++ b/.github/workflows/cppcheck.versions.yml
@@ -1,0 +1,29 @@
+name: cppcheck-deps
+
+on:
+  schedule:
+  - cron: "30 4 * * *"
+
+jobs:
+  apt-get:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set versions
+        id: version
+        run: |
+          echo ::set-output name=type::cppcheck
+
+      - name: Upgrade dependencies
+        run: |
+          make apt-${{ steps.version.outputs.type }}
+          git status
+
+      - name: Commit the dependency changes
+        uses: cardboardci/github-actions/auto-commit@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: '/deps'
+          MESSAGE: 'Upgrade packages to latest dependencies'
+          PULL_REQUEST_TITLE: 'Bump image dependencies to latest'


### PR DESCRIPTION
A scheduled task that will check package managers for the latest available version of a dependency, then raise a pull request if new versions have been discovered.

This'll need to be revised a bit to be more resilient, and handle the edge cases better.