### PR TITLE
The luarocks dependency check is hanging on an interactive check

### DIFF
--- a/.github/workflows/latex.versions.yml
+++ b/.github/workflows/latex.versions.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Upgrade dependencies
         run: |
           make apt-${{ steps.version.outputs.type }}
-          make luarocks-${{ steps.version.outputs.type }}
           git status
 
       - name: Commit the dependency changes

--- a/.github/workflows/luacheck.versions.yml
+++ b/.github/workflows/luacheck.versions.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Upgrade dependencies
         run: |
           make apt-${{ steps.version.outputs.type }}
+          make luarocks-${{ steps.version.outputs.type }}
           git status
 
       - name: Commit the dependency changes

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ apt-% : ; ## Upgrades the apt deps
 		--rm \
 		--user=root \
 		--entrypoint="" \
+		-e DEBIAN_FRONTEND=noninteractive \
 		-v "$(DIR)":/workspace \
 		--workdir=/workspace \
 		cardboardci/ci-core:latest bash tools/apt.bash $*
@@ -24,6 +25,7 @@ npm-% : ; ## Upgrades the npm deps
 		--rm \
 		--user=root \
 		--entrypoint="" \
+		-e DEBIAN_FRONTEND=noninteractive \
 		-v "$(DIR)":/workspace \
 		--workdir=/workspace \
 		node:latest bash tools/npm.bash $*
@@ -33,6 +35,7 @@ gem-% : ; ## Upgrades the gem deps
 		--rm \
 		--user=root \
 		--entrypoint="" \
+		-e DEBIAN_FRONTEND=noninteractive \
 		-v "$(DIR)":/workspace \
 		--workdir=/workspace \
 		ruby:latest bash tools/gem.bash $*
@@ -42,6 +45,7 @@ luarocks-% : ; ## Upgrades the lua deps
 		--rm \
 		--user=root \
 		--entrypoint="" \
+		-e DEBIAN_FRONTEND=noninteractive \
 		-v "$(DIR)":/workspace \
 		--workdir=/workspace \
 		ubuntu:latest bash tools/luarocks.bash $*

--- a/tools/luarocks.bash
+++ b/tools/luarocks.bash
@@ -3,7 +3,7 @@ set -e
 CONTAINER="images/$@"
 
 apt update -qq
-apt install -qq luarocks -y
+apt install -qq -y luarocks
 
 # Emit the current versions
 echo "Current versions"


### PR DESCRIPTION
The luarocks downloader setup was encountering an interactive blocker, which prevented the check from progressing. This PR ensures that these will run in  a non-interactive execution.

Additionally the luarocks check was occurring in the latex image, when it should have been occurring in the luacheck image.

Setting up a downloader image would be better, as that would allow for testing to ensure scenarios like this don't happen in the future.