### PR TITLE
Inline auto-commit to allow adjustment to downloader

### DIFF
--- a/.github/actions/auto-commit/Dockerfile
+++ b/.github/actions/auto-commit/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:focal-20191030
+
+LABEL "name"="auto-commit"
+LABEL "maintainer"="Jonathan Beverly <jonathan@jrbeverly.me>"
+LABEL "version"="0.0.1"
+
+LABEL "com.github.actions.name"="Auto-commit for GitHub Actions"
+LABEL "com.github.actions.description"="Commits and raises a pull request for the changes"
+LABEL "com.github.actions.icon"="git"
+LABEL "com.github.actions.color"="purple"
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y git jq curl ca-certificates wget \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN wget -O hub.tgz "https://github.com/github/hub/releases/download/v2.12.8/hub-linux-amd64-2.12.8.tgz" \
+    && tar -xvf hub.tgz --strip-components 1 -C /usr/local;
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["bash", "/entrypoint.sh"]

--- a/.github/actions/auto-commit/entrypoint.sh
+++ b/.github/actions/auto-commit/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+if [[ -z "$GITHUB_TOKEN" ]]; then
+	echo "Set the GITHUB_TOKEN env variable."
+	exit 1
+fi
+
+if [ -z "$(git status --porcelain)" ]; then 
+	echo "The working directory is clean. Nothing to do."
+	exit
+fi
+
+# Configure git
+git config --global user.name "${GITHUB_ACTOR}"
+git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+git config --global http.sslverify false
+
+## Commit changes
+action_branch="gh-actions/$(shuf -i 2000-65000 -n 1)$BRANCH"
+git checkout -b "${action_branch}"
+git add *
+git commit -m "$MESSAGE"
+
+## Add authenticated remote
+git remote add github "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+git push -u github HEAD
+
+## Create a pull request
+hub pull-request -m "${PULL_REQUEST_TITLE}" $PULL_REQUEST_OPTIONS

--- a/.github/workflows/awscli.versions.yml
+++ b/.github/workflows/awscli.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: cardboardci/github-actions/auto-commit@master
+        uses: .github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/bats.versions.yml
+++ b/.github/workflows/bats.versions.yml
@@ -22,7 +22,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: cardboardci/github-actions/auto-commit@master
+        uses: .github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/cppcheck.versions.yml
+++ b/.github/workflows/cppcheck.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: cardboardci/github-actions/auto-commit@master
+        uses: .github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/dbxcli.versions.yml
+++ b/.github/workflows/dbxcli.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: cardboardci/github-actions/auto-commit@master
+        uses: .github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/ecr.versions.yml
+++ b/.github/workflows/ecr.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: cardboardci/github-actions/auto-commit@master
+        uses: .github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/github.versions.yml
+++ b/.github/workflows/github.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: cardboardci/github-actions/auto-commit@master
+        uses: .github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/gitlab.versions.yml
+++ b/.github/workflows/gitlab.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: cardboardci/github-actions/auto-commit@master
+        uses: .github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/hadolint.versions.yml
+++ b/.github/workflows/hadolint.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: cardboardci/github-actions/auto-commit@master
+        uses: .github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/htmlhint.versions.yml
+++ b/.github/workflows/htmlhint.versions.yml
@@ -22,7 +22,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: cardboardci/github-actions/auto-commit@master
+        uses: .github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/hugo.versions.yml
+++ b/.github/workflows/hugo.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: cardboardci/github-actions/auto-commit@master
+        uses: .github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/latex.versions.yml
+++ b/.github/workflows/latex.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: cardboardci/github-actions/auto-commit@master
+        uses: .github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/luacheck.versions.yml
+++ b/.github/workflows/luacheck.versions.yml
@@ -22,7 +22,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: cardboardci/github-actions/auto-commit@master
+        uses: .github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/markdownlint.versions.yml
+++ b/.github/workflows/markdownlint.versions.yml
@@ -22,7 +22,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: cardboardci/github-actions/auto-commit@master
+        uses: .github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/netlify.versions.yml
+++ b/.github/workflows/netlify.versions.yml
@@ -22,7 +22,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: cardboardci/github-actions/auto-commit@master
+        uses: .github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/pdf2htmlex.versions.yml
+++ b/.github/workflows/pdf2htmlex.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: cardboardci/github-actions/auto-commit@master
+        uses: .github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/pdftools.versions.yml
+++ b/.github/workflows/pdftools.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: cardboardci/github-actions/auto-commit@master
+        uses: .github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/psscriptanalyzer.versions.yml
+++ b/.github/workflows/psscriptanalyzer.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: cardboardci/github-actions/auto-commit@master
+        uses: .github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/pylint.versions.yml
+++ b/.github/workflows/pylint.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: cardboardci/github-actions/auto-commit@master
+        uses: .github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/rsvg.versions.yml
+++ b/.github/workflows/rsvg.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: cardboardci/github-actions/auto-commit@master
+        uses: .github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/rubocop.versions.yml
+++ b/.github/workflows/rubocop.versions.yml
@@ -22,7 +22,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: cardboardci/github-actions/auto-commit@master
+        uses: .github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/shellcheck.versions.yml
+++ b/.github/workflows/shellcheck.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: cardboardci/github-actions/auto-commit@master
+        uses: .github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/stylelint.versions.yml
+++ b/.github/workflows/stylelint.versions.yml
@@ -22,7 +22,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: cardboardci/github-actions/auto-commit@master
+        uses: .github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/surge.versions.yml
+++ b/.github/workflows/surge.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: cardboardci/github-actions/auto-commit@master
+        uses: .github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/svgtools.versions.yml
+++ b/.github/workflows/svgtools.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: cardboardci/github-actions/auto-commit@master
+        uses: .github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/tflint.versions.yml
+++ b/.github/workflows/tflint.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: cardboardci/github-actions/auto-commit@master
+        uses: .github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/wkhtmltopdf.versions.yml
+++ b/.github/workflows/wkhtmltopdf.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: cardboardci/github-actions/auto-commit@master
+        uses: .github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'


### PR DESCRIPTION
Inline the auto-commit action as a defined action within the repository. Replacing the usages in all the version updater workflows.

I expect to inline some core actions into the repository for the time being while they are unstable. When they become stable, they can be moved back into the `actions` repository for the organization.