### PR TITLE
On README change, update dockerhub desc

### DIFF
--- a/.github/workflows/rsvg.hub.yml
+++ b/.github/workflows/rsvg.hub.yml
@@ -1,0 +1,21 @@
+name: rsvg-hub
+on:
+  push:
+    branches:
+      - master
+    paths:
+    - definitions/rsvg/README.md
+    - .github/workflows/rsvg.hub.yml
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@v2.1.0
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+          DOCKERHUB_REPOSITORY: cardboardci/rsvg
+          README_FILEPATH: definitions/rsvg/README.md


### PR DESCRIPTION
The rsvg image is missing the dockerhub description update workflow. This adds that in.