### PR TITLE
Remove unused build variables from workflows

### DIFF
--- a/.github/workflows/awscli.build.yml
+++ b/.github/workflows/awscli.build.yml
@@ -19,15 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set versions
-        id: version
-        run: |
-          echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::images/awscli
-
-      - name: Set tag var
+      - name: Set image variables
         id: vars
         run: |
+          echo ::set-output name=docker_path::images/awscli
+          echo ::set-output name=dockerfile::images/awscli/Dockerfile
+          echo ::set-output name=dockerdir::images/awscli/.
+          echo ::set-output name=hadolint_config::images/awscli/.hadolint.yaml
           echo ::set-output name=docker_image::docker.io/cardboardci/awscli
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 

--- a/.github/workflows/awscli.build.yml
+++ b/.github/workflows/awscli.build.yml
@@ -32,18 +32,18 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint images/awscli/Dockerfile"
+          args: "hadolint --config=${{ steps.vars.outputs.hadolint_config }} ${{ steps.vars.outputs.dockerfile }}"
 
       - name: Build
         run: |
-          docker build ${{ steps.version.outputs.docker_path }}/. \
-            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+          docker build ${{ steps.vars.outputs.dockerdir }} \
+            --file ${{ steps.vars.outputs.dockerfile }} \
             --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
 
       - name: Tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test
         with:
-          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Deploy to DockerHub
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/awscli.build.yml
+++ b/.github/workflows/awscli.build.yml
@@ -11,6 +11,7 @@ on:
       - images/awscli/tests/*
       - images/awscli/tests/*/*
       - images/awscli/Dockerfile
+      - images/awscli/.hadolint.yaml
       - .github/workflows/awscli.build.yml
 
 jobs:

--- a/.github/workflows/base.build.yml
+++ b/.github/workflows/base.build.yml
@@ -11,6 +11,7 @@ on:
       - base/tests/*
       - base/tests/*/*
       - base/Dockerfile
+      - base/Dockerfile/.hadolint.yaml
       - .github/workflows/base.build.yml
 
 jobs:

--- a/.github/workflows/cppcheck.build.yml
+++ b/.github/workflows/cppcheck.build.yml
@@ -19,15 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set versions
-        id: version
-        run: |
-          echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::images/cppcheck
-
-      - name: Set tag var
+      - name: Set image variables
         id: vars
         run: |
+          echo ::set-output name=docker_path::images/cppcheck
+          echo ::set-output name=dockerfile::images/cppcheck/Dockerfile
+          echo ::set-output name=dockerdir::images/cppcheck/.
+          echo ::set-output name=hadolint_config::images/cppcheck/.hadolint.yaml
           echo ::set-output name=docker_image::docker.io/cardboardci/cppcheck
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 

--- a/.github/workflows/cppcheck.build.yml
+++ b/.github/workflows/cppcheck.build.yml
@@ -11,6 +11,7 @@ on:
       - images/cppcheck/tests/*
       - images/cppcheck/tests/*/*
       - images/cppcheck/Dockerfile
+      - images/cppcheck/.hadolint.yaml
       - .github/workflows/cppcheck.build.yml
 
 jobs:

--- a/.github/workflows/cppcheck.build.yml
+++ b/.github/workflows/cppcheck.build.yml
@@ -32,18 +32,18 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint images/cppcheck/Dockerfile"
+          args: "hadolint --config=${{ steps.vars.outputs.hadolint_config }} ${{ steps.vars.outputs.dockerfile }}"
 
       - name: Build
         run: |
-          docker build ${{ steps.version.outputs.docker_path }}/. \
-            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+          docker build ${{ steps.vars.outputs.dockerdir }} \
+            --file ${{ steps.vars.outputs.dockerfile }} \
             --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
 
       - name: Tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test
         with:
-          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Deploy to DockerHub
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/dbxcli.build.yml
+++ b/.github/workflows/dbxcli.build.yml
@@ -19,15 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set versions
-        id: version
-        run: |
-          echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::images/dbxcli
-
-      - name: Set tag var
+      - name: Set image variables
         id: vars
         run: |
+          echo ::set-output name=docker_path::images/dbxcli
+          echo ::set-output name=dockerfile::images/dbxcli/Dockerfile
+          echo ::set-output name=dockerdir::images/dbxcli/.
+          echo ::set-output name=hadolint_config::images/dbxcli/.hadolint.yaml
           echo ::set-output name=docker_image::docker.io/cardboardci/dbxcli
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 

--- a/.github/workflows/dbxcli.build.yml
+++ b/.github/workflows/dbxcli.build.yml
@@ -11,6 +11,7 @@ on:
       - images/dbxcli/tests/*
       - images/dbxcli/tests/*/*
       - images/dbxcli/Dockerfile
+      - images/dbxcli/.hadolint.yaml
       - .github/workflows/dbxcli.build.yml
 
 jobs:

--- a/.github/workflows/dbxcli.build.yml
+++ b/.github/workflows/dbxcli.build.yml
@@ -32,18 +32,18 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint --config=images/dbxcli/.hadolint.yaml images/dbxcli/Dockerfile"
+          args: "hadolint --config=${{ steps.vars.outputs.hadolint_config }} ${{ steps.vars.outputs.dockerfile }}"
 
       - name: Build
         run: |
-          docker build ${{ steps.version.outputs.docker_path }}/. \
-            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+          docker build ${{ steps.vars.outputs.dockerdir }} \
+            --file ${{ steps.vars.outputs.dockerfile }} \
             --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
 
       - name: Tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test
         with:
-          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Deploy to DockerHub
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/ecr.build.yml
+++ b/.github/workflows/ecr.build.yml
@@ -19,15 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set versions
-        id: version
-        run: |
-          echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::images/ecr
-
-      - name: Set tag var
+      - name: Set image variables
         id: vars
         run: |
+          echo ::set-output name=docker_path::images/ecr
+          echo ::set-output name=dockerfile::images/ecr/Dockerfile
+          echo ::set-output name=dockerdir::images/ecr/.
+          echo ::set-output name=hadolint_config::images/ecr/.hadolint.yaml
           echo ::set-output name=docker_image::docker.io/cardboardci/ecr
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 

--- a/.github/workflows/ecr.build.yml
+++ b/.github/workflows/ecr.build.yml
@@ -11,6 +11,7 @@ on:
       - images/ecr/tests/*
       - images/ecr/tests/*/*
       - images/ecr/Dockerfile
+      - images/ecr/.hadolint.yaml
       - .github/workflows/ecr.build.yml
 
 jobs:

--- a/.github/workflows/ecr.build.yml
+++ b/.github/workflows/ecr.build.yml
@@ -32,18 +32,18 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint images/ecr/Dockerfile"
+          args: "hadolint --config=${{ steps.vars.outputs.hadolint_config }} ${{ steps.vars.outputs.dockerfile }}"
 
       - name: Build
         run: |
-          docker build ${{ steps.version.outputs.docker_path }}/. \
-            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+          docker build ${{ steps.vars.outputs.dockerdir }} \
+            --file ${{ steps.vars.outputs.dockerfile }} \
             --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
 
       - name: Tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test
         with:
-          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Deploy to DockerHub
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/github.build.yml
+++ b/.github/workflows/github.build.yml
@@ -11,6 +11,7 @@ on:
       - images/github/tests/*
       - images/github/tests/*/*
       - images/github/Dockerfile
+      - images/github/.hadolint.yaml
       - .github/workflows/github.build.yml
 
 jobs:

--- a/.github/workflows/github.build.yml
+++ b/.github/workflows/github.build.yml
@@ -32,18 +32,18 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint images/github/Dockerfile"
+          args: "hadolint --config=${{ steps.vars.outputs.hadolint_config }} ${{ steps.vars.outputs.dockerfile }}"
 
       - name: Build
         run: |
-          docker build ${{ steps.version.outputs.docker_path }}/. \
-            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+          docker build ${{ steps.vars.outputs.dockerdir }} \
+            --file ${{ steps.vars.outputs.dockerfile }} \
             --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
 
       - name: Tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test
         with:
-          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Deploy to DockerHub
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/github.build.yml
+++ b/.github/workflows/github.build.yml
@@ -19,15 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set versions
-        id: version
-        run: |
-          echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::images/github
-
-      - name: Set tag var
+      - name: Set image variables
         id: vars
         run: |
+          echo ::set-output name=docker_path::images/github
+          echo ::set-output name=dockerfile::images/github/Dockerfile
+          echo ::set-output name=dockerdir::images/github/.
+          echo ::set-output name=hadolint_config::images/github/.hadolint.yaml
           echo ::set-output name=docker_image::docker.io/cardboardci/github
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 

--- a/.github/workflows/gitlab.build.yml
+++ b/.github/workflows/gitlab.build.yml
@@ -11,6 +11,7 @@ on:
       - images/gitlab/tests/*
       - images/gitlab/tests/*/*
       - images/gitlab/Dockerfile
+      - images/gitlab/.hadolint.yaml
       - .github/workflows/gitlab.build.yml
 
 jobs:

--- a/.github/workflows/gitlab.build.yml
+++ b/.github/workflows/gitlab.build.yml
@@ -32,18 +32,18 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint --config images/gitlab/.hadolint.yaml images/gitlab/Dockerfile"
+          args: "hadolint --config=${{ steps.vars.outputs.hadolint_config }} ${{ steps.vars.outputs.dockerfile }}"
 
       - name: Build
         run: |
-          docker build ${{ steps.version.outputs.docker_path }}/. \
-            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+          docker build ${{ steps.vars.outputs.dockerdir }} \
+            --file ${{ steps.vars.outputs.dockerfile }} \
             --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
 
       - name: Tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test
         with:
-          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Deploy to DockerHub
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/gitlab.build.yml
+++ b/.github/workflows/gitlab.build.yml
@@ -19,15 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set versions
-        id: version
-        run: |
-          echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::images/gitlab
-
-      - name: Set tag var
+      - name: Set image variables
         id: vars
         run: |
+          echo ::set-output name=docker_path::images/gitlab
+          echo ::set-output name=dockerfile::images/gitlab/Dockerfile
+          echo ::set-output name=dockerdir::images/gitlab/.
+          echo ::set-output name=hadolint_config::images/gitlab/.hadolint.yaml
           echo ::set-output name=docker_image::docker.io/cardboardci/gitlab
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 

--- a/.github/workflows/hadolint.build.yml
+++ b/.github/workflows/hadolint.build.yml
@@ -11,6 +11,7 @@ on:
       - images/hadolint/tests/*
       - images/hadolint/tests/*/*
       - images/hadolint/Dockerfile
+      - images/hadolint/.hadolint.yaml
       - .github/workflows/hadolint.build.yml
 
 jobs:

--- a/.github/workflows/hadolint.build.yml
+++ b/.github/workflows/hadolint.build.yml
@@ -19,15 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set versions
-        id: version
-        run: |
-          echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::images/hadolint
-
-      - name: Set tag var
+      - name: Set image variables
         id: vars
         run: |
+          echo ::set-output name=docker_path::images/hadolint
+          echo ::set-output name=dockerfile::images/hadolint/Dockerfile
+          echo ::set-output name=dockerdir::images/hadolint/.
+          echo ::set-output name=hadolint_config::images/hadolint/.hadolint.yaml
           echo ::set-output name=docker_image::docker.io/cardboardci/hadolint
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 

--- a/.github/workflows/hadolint.build.yml
+++ b/.github/workflows/hadolint.build.yml
@@ -32,18 +32,18 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint --config=images/hadolint/.hadolint.yaml images/hadolint/Dockerfile"
+          args: "hadolint --config=${{ steps.vars.outputs.hadolint_config }} ${{ steps.vars.outputs.dockerfile }}"
 
       - name: Build
         run: |
-          docker build ${{ steps.version.outputs.docker_path }}/. \
-            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+          docker build ${{ steps.vars.outputs.dockerdir }} \
+            --file ${{ steps.vars.outputs.dockerfile }} \
             --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
 
       - name: Tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test
         with:
-          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Deploy to DockerHub
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/htmlhint.build.yml
+++ b/.github/workflows/htmlhint.build.yml
@@ -32,18 +32,18 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint images/htmlhint/Dockerfile"
+          args: "hadolint --config=${{ steps.vars.outputs.hadolint_config }} ${{ steps.vars.outputs.dockerfile }}"
 
       - name: Build
         run: |
-          docker build ${{ steps.version.outputs.docker_path }}/. \
-            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+          docker build ${{ steps.vars.outputs.dockerdir }} \
+            --file ${{ steps.vars.outputs.dockerfile }} \
             --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
 
       - name: Tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test
         with:
-          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Deploy to DockerHub
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/htmlhint.build.yml
+++ b/.github/workflows/htmlhint.build.yml
@@ -11,6 +11,7 @@ on:
       - images/htmlhint/tests/*
       - images/htmlhint/tests/*/*
       - images/htmlhint/Dockerfile
+      - images/htmlhint/.hadolint.yaml
       - .github/workflows/htmlhint.build.yml
 
 jobs:

--- a/.github/workflows/htmlhint.build.yml
+++ b/.github/workflows/htmlhint.build.yml
@@ -19,15 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set versions
-        id: version
-        run: |
-          echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::images/htmlhint
-
-      - name: Set tag var
+      - name: Set image variables
         id: vars
         run: |
+          echo ::set-output name=docker_path::images/htmlhint
+          echo ::set-output name=dockerfile::images/htmlhint/Dockerfile
+          echo ::set-output name=dockerdir::images/htmlhint/.
+          echo ::set-output name=hadolint_config::images/htmlhint/.hadolint.yaml
           echo ::set-output name=docker_image::docker.io/cardboardci/htmlhint
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 

--- a/.github/workflows/hugo.build.yml
+++ b/.github/workflows/hugo.build.yml
@@ -11,6 +11,7 @@ on:
       - images/hugo/tests/*
       - images/hugo/tests/*/*
       - images/hugo/Dockerfile
+      - images/hugo/.hadolint.yaml
       - .github/workflows/hugo.build.yml
 
 jobs:

--- a/.github/workflows/hugo.build.yml
+++ b/.github/workflows/hugo.build.yml
@@ -19,15 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set versions
-        id: version
-        run: |
-          echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::images/hugo
-
-      - name: Set tag var
+      - name: Set image variables
         id: vars
         run: |
+          echo ::set-output name=docker_path::images/hugo
+          echo ::set-output name=dockerfile::images/hugo/Dockerfile
+          echo ::set-output name=dockerdir::images/hugo/.
+          echo ::set-output name=hadolint_config::images/hugo/.hadolint.yaml
           echo ::set-output name=docker_image::docker.io/cardboardci/hugo
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 

--- a/.github/workflows/hugo.build.yml
+++ b/.github/workflows/hugo.build.yml
@@ -32,18 +32,18 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint images/hugo/Dockerfile"
+          args: "hadolint --config=${{ steps.vars.outputs.hadolint_config }} ${{ steps.vars.outputs.dockerfile }}"
 
       - name: Build
         run: |
-          docker build ${{ steps.version.outputs.docker_path }}/. \
-            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+          docker build ${{ steps.vars.outputs.dockerdir }} \
+            --file ${{ steps.vars.outputs.dockerfile }} \
             --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
 
       - name: Tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test
         with:
-          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Deploy to DockerHub
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/latex.build.yml
+++ b/.github/workflows/latex.build.yml
@@ -19,15 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set versions
-        id: version
-        run: |
-          echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::images/latex
-
-      - name: Set tag var
+      - name: Set image variables
         id: vars
         run: |
+          echo ::set-output name=docker_path::images/latex
+          echo ::set-output name=dockerfile::images/latex/Dockerfile
+          echo ::set-output name=dockerdir::images/latex/.
+          echo ::set-output name=hadolint_config::images/latex/.hadolint.yaml
           echo ::set-output name=docker_image::docker.io/cardboardci/latex
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 

--- a/.github/workflows/latex.build.yml
+++ b/.github/workflows/latex.build.yml
@@ -11,6 +11,7 @@ on:
       - images/latex/tests/*
       - images/latex/tests/*/*
       - images/latex/Dockerfile
+      - images/latex/.hadolint.yaml
       - .github/workflows/latex.build.yml
 
 jobs:

--- a/.github/workflows/latex.build.yml
+++ b/.github/workflows/latex.build.yml
@@ -32,18 +32,18 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint images/latex/Dockerfile"
+          args: "hadolint --config=${{ steps.vars.outputs.hadolint_config }} ${{ steps.vars.outputs.dockerfile }}"
 
       - name: Build
         run: |
-          docker build ${{ steps.version.outputs.docker_path }}/. \
-            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+          docker build ${{ steps.vars.outputs.dockerdir }} \
+            --file ${{ steps.vars.outputs.dockerfile }} \
             --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
 
       - name: Tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test
         with:
-          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Deploy to DockerHub
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/luacheck.build.yml
+++ b/.github/workflows/luacheck.build.yml
@@ -11,6 +11,7 @@ on:
       - images/luacheck/tests/*
       - images/luacheck/tests/*/*
       - images/luacheck/Dockerfile
+      - images/luacheck/.hadolint.yaml
       - .github/workflows/luacheck.build.yml
 
 jobs:

--- a/.github/workflows/luacheck.build.yml
+++ b/.github/workflows/luacheck.build.yml
@@ -19,15 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set versions
-        id: version
-        run: |
-          echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::images/luacheck
-
-      - name: Set tag var
+      - name: Set image variables
         id: vars
         run: |
+          echo ::set-output name=docker_path::images/luacheck
+          echo ::set-output name=dockerfile::images/luacheck/Dockerfile
+          echo ::set-output name=dockerdir::images/luacheck/.
+          echo ::set-output name=hadolint_config::images/luacheck/.hadolint.yaml
           echo ::set-output name=docker_image::docker.io/cardboardci/luacheck
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 

--- a/.github/workflows/luacheck.build.yml
+++ b/.github/workflows/luacheck.build.yml
@@ -32,22 +32,21 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint images/luacheck/Dockerfile"
+          args: "hadolint --config=${{ steps.vars.outputs.hadolint_config }} ${{ steps.vars.outputs.dockerfile }}"
 
       - name: Build
         run: |
-          docker build ${{ steps.version.outputs.docker_path }}/. \
-            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+          docker build ${{ steps.vars.outputs.dockerdir }} \
+            --file ${{ steps.vars.outputs.dockerfile }} \
             --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
 
       - name: Tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test
         with:
-          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Deploy to DockerHub
         if: github.ref == 'refs/heads/master'
         run: |
           echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}
-

--- a/.github/workflows/markdownlint.build.yml
+++ b/.github/workflows/markdownlint.build.yml
@@ -11,6 +11,7 @@ on:
       - images/markdownlint/tests/*
       - images/markdownlint/tests/*/*
       - images/markdownlint/Dockerfile
+      - images/markdownlint/.hadolint.yaml
       - .github/workflows/markdownlint.build.yml
 
 jobs:

--- a/.github/workflows/markdownlint.build.yml
+++ b/.github/workflows/markdownlint.build.yml
@@ -32,18 +32,18 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint images/markdownlint/Dockerfile"
+          args: "hadolint --config=${{ steps.vars.outputs.hadolint_config }} ${{ steps.vars.outputs.dockerfile }}"
 
       - name: Build
         run: |
-          docker build ${{ steps.version.outputs.docker_path }}/. \
-            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+          docker build ${{ steps.vars.outputs.dockerdir }} \
+            --file ${{ steps.vars.outputs.dockerfile }} \
             --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
 
       - name: Tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test
         with:
-          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Deploy to DockerHub
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/markdownlint.build.yml
+++ b/.github/workflows/markdownlint.build.yml
@@ -19,15 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set versions
-        id: version
-        run: |
-          echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::images/markdownlint
-
-      - name: Set tag var
+      - name: Set image variables
         id: vars
         run: |
+          echo ::set-output name=docker_path::images/markdownlint
+          echo ::set-output name=dockerfile::images/markdownlint/Dockerfile
+          echo ::set-output name=dockerdir::images/markdownlint/.
+          echo ::set-output name=hadolint_config::images/markdownlint/.hadolint.yaml
           echo ::set-output name=docker_image::docker.io/cardboardci/markdownlint
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 

--- a/.github/workflows/netlify.build.yml
+++ b/.github/workflows/netlify.build.yml
@@ -11,6 +11,7 @@ on:
       - images/netlify/tests/*
       - images/netlify/tests/*/*
       - images/netlify/Dockerfile
+      - images/netlify/.hadolint.yaml
       - .github/workflows/netlify.build.yml
 
 jobs:

--- a/.github/workflows/netlify.build.yml
+++ b/.github/workflows/netlify.build.yml
@@ -19,15 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set versions
-        id: version
-        run: |
-          echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::images/netlify
-
-      - name: Set tag var
+      - name: Set image variables
         id: vars
         run: |
+          echo ::set-output name=docker_path::images/netlify
+          echo ::set-output name=dockerfile::images/netlify/Dockerfile
+          echo ::set-output name=dockerdir::images/netlify/.
+          echo ::set-output name=hadolint_config::images/netlify/.hadolint.yaml
           echo ::set-output name=docker_image::docker.io/cardboardci/netlify
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 

--- a/.github/workflows/netlify.build.yml
+++ b/.github/workflows/netlify.build.yml
@@ -32,18 +32,18 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint images/netlify/Dockerfile"
+          args: "hadolint --config=${{ steps.vars.outputs.hadolint_config }} ${{ steps.vars.outputs.dockerfile }}"
 
       - name: Build
         run: |
-          docker build ${{ steps.version.outputs.docker_path }}/. \
-            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+          docker build ${{ steps.vars.outputs.dockerdir }} \
+            --file ${{ steps.vars.outputs.dockerfile }} \
             --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
 
       - name: Tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test
         with:
-          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Deploy to DockerHub
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/pdf2htmlex.build.yml
+++ b/.github/workflows/pdf2htmlex.build.yml
@@ -19,15 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set versions
-        id: version
-        run: |
-          echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::images/pdf2htmlex
-
-      - name: Set tag var
+      - name: Set image variables
         id: vars
         run: |
+          echo ::set-output name=docker_path::images/pdf2htmlex
+          echo ::set-output name=dockerfile::images/pdf2htmlex/Dockerfile
+          echo ::set-output name=dockerdir::images/pdf2htmlex/.
+          echo ::set-output name=hadolint_config::images/pdf2htmlex/.hadolint.yaml
           echo ::set-output name=docker_image::docker.io/cardboardci/pdf2htmlex
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 

--- a/.github/workflows/pdf2htmlex.build.yml
+++ b/.github/workflows/pdf2htmlex.build.yml
@@ -32,18 +32,18 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint images/pdf2htmlex/Dockerfile"
+          args: "hadolint --config=${{ steps.vars.outputs.hadolint_config }} ${{ steps.vars.outputs.dockerfile }}"
 
       - name: Build
         run: |
-          docker build ${{ steps.version.outputs.docker_path }}/. \
-            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+          docker build ${{ steps.vars.outputs.dockerdir }} \
+            --file ${{ steps.vars.outputs.dockerfile }} \
             --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
 
       - name: Tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test
         with:
-          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Deploy to DockerHub
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/pdf2htmlex.build.yml
+++ b/.github/workflows/pdf2htmlex.build.yml
@@ -11,6 +11,7 @@ on:
       - images/pdf2htmlex/tests/*
       - images/pdf2htmlex/tests/*/*
       - images/pdf2htmlex/Dockerfile
+      - images/pdf2htmlex/.hadolint.yaml
       - .github/workflows/pdf2htmlex.build.yml
 
 jobs:

--- a/.github/workflows/pdftools.build.yml
+++ b/.github/workflows/pdftools.build.yml
@@ -11,6 +11,7 @@ on:
       - images/pdftools/tests/*
       - images/pdftools/tests/*/*
       - images/pdftools/Dockerfile
+      - images/pdftools/.hadolint.yaml
       - .github/workflows/pdftools.build.yml
 
 jobs:

--- a/.github/workflows/pdftools.build.yml
+++ b/.github/workflows/pdftools.build.yml
@@ -19,15 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set versions
-        id: version
-        run: |
-          echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::images/pdftools
-
-      - name: Set tag var
+      - name: Set image variables
         id: vars
         run: |
+          echo ::set-output name=docker_path::images/pdftools
+          echo ::set-output name=dockerfile::images/pdftools/Dockerfile
+          echo ::set-output name=dockerdir::images/pdftools/.
+          echo ::set-output name=hadolint_config::images/pdftools/.hadolint.yaml
           echo ::set-output name=docker_image::docker.io/cardboardci/pdftools
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 

--- a/.github/workflows/pdftools.build.yml
+++ b/.github/workflows/pdftools.build.yml
@@ -32,18 +32,18 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint images/pdftools/Dockerfile"
+          args: "hadolint --config=${{ steps.vars.outputs.hadolint_config }} ${{ steps.vars.outputs.dockerfile }}"
 
       - name: Build
         run: |
-          docker build ${{ steps.version.outputs.docker_path }}/. \
-            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+          docker build ${{ steps.vars.outputs.dockerdir }} \
+            --file ${{ steps.vars.outputs.dockerfile }} \
             --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
 
       - name: Tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test
         with:
-          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Deploy to DockerHub
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/psscriptanalyzer.build.yml
+++ b/.github/workflows/psscriptanalyzer.build.yml
@@ -32,18 +32,18 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint --config=images/psscriptanalyzer/.hadolint.yaml images/psscriptanalyzer/Dockerfile"
+          args: "hadolint --config=${{ steps.vars.outputs.hadolint_config }} ${{ steps.vars.outputs.dockerfile }}"
 
       - name: Build
         run: |
-          docker build ${{ steps.version.outputs.docker_path }}/. \
-            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+          docker build ${{ steps.vars.outputs.dockerdir }} \
+            --file ${{ steps.vars.outputs.dockerfile }} \
             --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
 
       - name: Tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test
         with:
-          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Deploy to DockerHub
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/psscriptanalyzer.build.yml
+++ b/.github/workflows/psscriptanalyzer.build.yml
@@ -19,15 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set versions
-        id: version
-        run: |
-          echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::images/psscriptanalyzer
-
-      - name: Set tag var
+      - name: Set image variables
         id: vars
         run: |
+          echo ::set-output name=docker_path::images/psscriptanalyzer
+          echo ::set-output name=dockerfile::images/psscriptanalyzer/Dockerfile
+          echo ::set-output name=dockerdir::images/psscriptanalyzer/.
+          echo ::set-output name=hadolint_config::images/psscriptanalyzer/.hadolint.yaml
           echo ::set-output name=docker_image::docker.io/cardboardci/psscriptanalyzer
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 

--- a/.github/workflows/psscriptanalyzer.build.yml
+++ b/.github/workflows/psscriptanalyzer.build.yml
@@ -11,6 +11,7 @@ on:
       - images/psscriptanalyzer/tests/*
       - images/psscriptanalyzer/tests/*/*
       - images/psscriptanalyzer/Dockerfile
+      - images/psscriptanalyzer/.hadolint.yaml
       - .github/workflows/psscriptanalyzer.build.yml
 
 jobs:

--- a/.github/workflows/pylint.build.yml
+++ b/.github/workflows/pylint.build.yml
@@ -19,15 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set versions
-        id: version
-        run: |
-          echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::images/pylint
-
-      - name: Set tag var
+      - name: Set image variables
         id: vars
         run: |
+          echo ::set-output name=docker_path::images/pylint
+          echo ::set-output name=dockerfile::images/pylint/Dockerfile
+          echo ::set-output name=dockerdir::images/pylint/.
+          echo ::set-output name=hadolint_config::images/pylint/.hadolint.yaml
           echo ::set-output name=docker_image::docker.io/cardboardci/pylint
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 

--- a/.github/workflows/pylint.build.yml
+++ b/.github/workflows/pylint.build.yml
@@ -32,18 +32,18 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint images/pylint/Dockerfile"
+          args: "hadolint --config=${{ steps.vars.outputs.hadolint_config }} ${{ steps.vars.outputs.dockerfile }}"
 
       - name: Build
         run: |
-          docker build ${{ steps.version.outputs.docker_path }}/. \
-            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+          docker build ${{ steps.vars.outputs.dockerdir }} \
+            --file ${{ steps.vars.outputs.dockerfile }} \
             --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
 
       - name: Tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test
         with:
-          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Deploy to DockerHub
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/pylint.build.yml
+++ b/.github/workflows/pylint.build.yml
@@ -11,6 +11,7 @@ on:
       - images/pylint/tests/*
       - images/pylint/tests/*/*
       - images/pylint/Dockerfile
+      - images/pylint/.hadolint.yaml
       - .github/workflows/pylint.build.yml
 
 jobs:

--- a/.github/workflows/rsvg.build.yml
+++ b/.github/workflows/rsvg.build.yml
@@ -11,6 +11,7 @@ on:
       - images/rsvg/tests/*
       - images/rsvg/tests/*/*
       - images/rsvg/Dockerfile
+      - images/rsvg/.hadolint.yaml
       - .github/workflows/rsvg.build.yml
 
 jobs:

--- a/.github/workflows/rsvg.build.yml
+++ b/.github/workflows/rsvg.build.yml
@@ -19,15 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set versions
-        id: version
-        run: |
-          echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::images/rsvg
-
-      - name: Set tag var
+      - name: Set image variables
         id: vars
         run: |
+          echo ::set-output name=docker_path::images/rsvg
+          echo ::set-output name=dockerfile::images/rsvg/Dockerfile
+          echo ::set-output name=dockerdir::images/rsvg/.
+          echo ::set-output name=hadolint_config::images/rsvg/.hadolint.yaml
           echo ::set-output name=docker_image::docker.io/cardboardci/rsvg
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 

--- a/.github/workflows/rsvg.build.yml
+++ b/.github/workflows/rsvg.build.yml
@@ -32,18 +32,18 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint images/rsvg/Dockerfile"
+          args: "hadolint --config=${{ steps.vars.outputs.hadolint_config }} ${{ steps.vars.outputs.dockerfile }}"
 
       - name: Build
         run: |
-          docker build ${{ steps.version.outputs.docker_path }}/. \
-            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+          docker build ${{ steps.vars.outputs.dockerdir }} \
+            --file ${{ steps.vars.outputs.dockerfile }} \
             --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
 
       - name: Tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test
         with:
-          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Deploy to DockerHub
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/rubocop.build.yml
+++ b/.github/workflows/rubocop.build.yml
@@ -11,6 +11,7 @@ on:
       - images/rubocop/tests/*
       - images/rubocop/tests/*/*
       - images/rubocop/Dockerfile
+      - images/rubocop/.hadolint.yaml
       - .github/workflows/rubocop.build.yml
 
 jobs:

--- a/.github/workflows/rubocop.build.yml
+++ b/.github/workflows/rubocop.build.yml
@@ -32,18 +32,18 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint images/rubocop/Dockerfile"
+          args: "hadolint --config=${{ steps.vars.outputs.hadolint_config }} ${{ steps.vars.outputs.dockerfile }}"
 
       - name: Build
         run: |
-          docker build ${{ steps.version.outputs.docker_path }}/. \
-            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+          docker build ${{ steps.vars.outputs.dockerdir }} \
+            --file ${{ steps.vars.outputs.dockerfile }} \
             --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
 
       - name: Tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test
         with:
-          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Deploy to DockerHub
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/rubocop.build.yml
+++ b/.github/workflows/rubocop.build.yml
@@ -19,15 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set versions
-        id: version
-        run: |
-          echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::images/rubocop
-
-      - name: Set tag var
+      - name: Set image variables
         id: vars
         run: |
+          echo ::set-output name=docker_path::images/rubocop
+          echo ::set-output name=dockerfile::images/rubocop/Dockerfile
+          echo ::set-output name=dockerdir::images/rubocop/.
+          echo ::set-output name=hadolint_config::images/rubocop/.hadolint.yaml
           echo ::set-output name=docker_image::docker.io/cardboardci/rubocop
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 

--- a/.github/workflows/shellcheck.build.yml
+++ b/.github/workflows/shellcheck.build.yml
@@ -32,18 +32,18 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint images/shellcheck/Dockerfile"
+          args: "hadolint --config=${{ steps.vars.outputs.hadolint_config }} ${{ steps.vars.outputs.dockerfile }}"
 
       - name: Build
         run: |
-          docker build ${{ steps.version.outputs.docker_path }}/. \
-            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+          docker build ${{ steps.vars.outputs.dockerdir }} \
+            --file ${{ steps.vars.outputs.dockerfile }} \
             --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
 
       - name: Tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test
         with:
-          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Deploy to DockerHub
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/shellcheck.build.yml
+++ b/.github/workflows/shellcheck.build.yml
@@ -11,6 +11,7 @@ on:
       - images/shellcheck/tests/*
       - images/shellcheck/tests/*/*
       - images/shellcheck/Dockerfile
+      - images/shellcheck/.hadolint.yaml
       - .github/workflows/shellcheck.build.yml
 
 jobs:

--- a/.github/workflows/shellcheck.build.yml
+++ b/.github/workflows/shellcheck.build.yml
@@ -19,15 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set versions
-        id: version
-        run: |
-          echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::images/shellcheck
-
-      - name: Set tag var
+      - name: Set image variables
         id: vars
         run: |
+          echo ::set-output name=docker_path::images/shellcheck
+          echo ::set-output name=dockerfile::images/shellcheck/Dockerfile
+          echo ::set-output name=dockerdir::images/shellcheck/.
+          echo ::set-output name=hadolint_config::images/shellcheck/.hadolint.yaml
           echo ::set-output name=docker_image::docker.io/cardboardci/shellcheck
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 

--- a/.github/workflows/stylelint.build.yml
+++ b/.github/workflows/stylelint.build.yml
@@ -11,6 +11,7 @@ on:
       - images/stylelint/tests/*
       - images/stylelint/tests/*/*
       - images/stylelint/Dockerfile
+      - images/stylelint/.hadolint.yaml
       - .github/workflows/stylelint.build.yml
 
 jobs:

--- a/.github/workflows/stylelint.build.yml
+++ b/.github/workflows/stylelint.build.yml
@@ -19,15 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set versions
-        id: version
-        run: |
-          echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::images/stylelint
-
-      - name: Set tag var
+      - name: Set image variables
         id: vars
         run: |
+          echo ::set-output name=docker_path::images/stylelint
+          echo ::set-output name=dockerfile::images/stylelint/Dockerfile
+          echo ::set-output name=dockerdir::images/stylelint/.
+          echo ::set-output name=hadolint_config::images/stylelint/.hadolint.yaml
           echo ::set-output name=docker_image::docker.io/cardboardci/stylelint
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 

--- a/.github/workflows/stylelint.build.yml
+++ b/.github/workflows/stylelint.build.yml
@@ -32,18 +32,18 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint images/stylelint/Dockerfile"
+          args: "hadolint --config=${{ steps.vars.outputs.hadolint_config }} ${{ steps.vars.outputs.dockerfile }}"
 
       - name: Build
         run: |
-          docker build ${{ steps.version.outputs.docker_path }}/. \
-            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+          docker build ${{ steps.vars.outputs.dockerdir }} \
+            --file ${{ steps.vars.outputs.dockerfile }} \
             --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
 
       - name: Tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test
         with:
-          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Deploy to DockerHub
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/surge.build.yml
+++ b/.github/workflows/surge.build.yml
@@ -19,15 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set versions
-        id: version
-        run: |
-          echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::images/surge
-
-      - name: Set tag var
+      - name: Set image variables
         id: vars
         run: |
+          echo ::set-output name=docker_path::images/surge
+          echo ::set-output name=dockerfile::images/surge/Dockerfile
+          echo ::set-output name=dockerdir::images/surge/.
+          echo ::set-output name=hadolint_config::images/surge/.hadolint.yaml
           echo ::set-output name=docker_image::docker.io/cardboardci/surge
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 

--- a/.github/workflows/surge.build.yml
+++ b/.github/workflows/surge.build.yml
@@ -11,6 +11,7 @@ on:
       - images/surge/tests/*
       - images/surge/tests/*/*
       - images/surge/Dockerfile
+      - images/surge/.hadolint.yaml
       - .github/workflows/surge.build.yml
 
 jobs:

--- a/.github/workflows/surge.build.yml
+++ b/.github/workflows/surge.build.yml
@@ -32,18 +32,18 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint images/surge/Dockerfile"
+          args: "hadolint --config=${{ steps.vars.outputs.hadolint_config }} ${{ steps.vars.outputs.dockerfile }}"
 
       - name: Build
         run: |
-          docker build ${{ steps.version.outputs.docker_path }}/. \
-            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+          docker build ${{ steps.vars.outputs.dockerdir }} \
+            --file ${{ steps.vars.outputs.dockerfile }} \
             --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
 
       - name: Tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test
         with:
-          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Deploy to DockerHub
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/svgtools.build.yml
+++ b/.github/workflows/svgtools.build.yml
@@ -19,15 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set versions
-        id: version
-        run: |
-          echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::images/svgtools
-
-      - name: Set tag var
+      - name: Set image variables
         id: vars
         run: |
+          echo ::set-output name=docker_path::images/svgtools
+          echo ::set-output name=dockerfile::images/svgtools/Dockerfile
+          echo ::set-output name=dockerdir::images/svgtools/.
+          echo ::set-output name=hadolint_config::images/svgtools/.hadolint.yaml
           echo ::set-output name=docker_image::docker.io/cardboardci/svgtools
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 

--- a/.github/workflows/svgtools.build.yml
+++ b/.github/workflows/svgtools.build.yml
@@ -11,6 +11,7 @@ on:
       - images/svgtools/tests/*
       - images/svgtools/tests/*/*
       - images/svgtools/Dockerfile
+      - images/svgtools/.hadolint.yaml
       - .github/workflows/svgtools.build.yml
 
 jobs:

--- a/.github/workflows/svgtools.build.yml
+++ b/.github/workflows/svgtools.build.yml
@@ -32,18 +32,18 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint images/svgtools/Dockerfile"
+          args: "hadolint --config=${{ steps.vars.outputs.hadolint_config }} ${{ steps.vars.outputs.dockerfile }}"
 
       - name: Build
         run: |
-          docker build ${{ steps.version.outputs.docker_path }}/. \
-            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+          docker build ${{ steps.vars.outputs.dockerdir }} \
+            --file ${{ steps.vars.outputs.dockerfile }} \
             --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
 
       - name: Tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test
         with:
-          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Deploy to DockerHub
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/tflint.build.yml
+++ b/.github/workflows/tflint.build.yml
@@ -32,18 +32,18 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint images/tflint/Dockerfile"
+          args: "hadolint --config=${{ steps.vars.outputs.hadolint_config }} ${{ steps.vars.outputs.dockerfile }}"
 
       - name: Build
         run: |
-          docker build ${{ steps.version.outputs.docker_path }}/. \
-            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+          docker build ${{ steps.vars.outputs.dockerdir }} \
+            --file ${{ steps.vars.outputs.dockerfile }} \
             --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
 
       - name: Tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test
         with:
-          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Deploy to DockerHub
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/tflint.build.yml
+++ b/.github/workflows/tflint.build.yml
@@ -11,6 +11,7 @@ on:
       - images/tflint/tests/*
       - images/tflint/tests/*/*
       - images/tflint/Dockerfile
+      - images/tflint/.hadolint.yaml
       - .github/workflows/tflint.build.yml
 
 jobs:

--- a/.github/workflows/tflint.build.yml
+++ b/.github/workflows/tflint.build.yml
@@ -19,15 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set versions
-        id: version
-        run: |
-          echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::images/tflint
-
-      - name: Set tag var
+      - name: Set image variables
         id: vars
         run: |
+          echo ::set-output name=docker_path::images/tflint
+          echo ::set-output name=dockerfile::images/tflint/Dockerfile
+          echo ::set-output name=dockerdir::images/tflint/.
+          echo ::set-output name=hadolint_config::images/tflint/.hadolint.yaml
           echo ::set-output name=docker_image::docker.io/cardboardci/tflint
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 

--- a/.github/workflows/wkhtmltopdf.build.yml
+++ b/.github/workflows/wkhtmltopdf.build.yml
@@ -11,6 +11,7 @@ on:
       - images/wkhtmltopdf/tests/*
       - images/wkhtmltopdf/tests/*/*
       - images/wkhtmltopdf/Dockerfile
+      - images/wkhtmltopdf/.hadolint.yaml
       - .github/workflows/wkhtmltopdf.build.yml
 
 jobs:

--- a/.github/workflows/wkhtmltopdf.build.yml
+++ b/.github/workflows/wkhtmltopdf.build.yml
@@ -19,15 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set versions
-        id: version
-        run: |
-          echo ::set-output name=docker_version::0.0.1
-          echo ::set-output name=docker_path::images/wkhtmltopdf
-
-      - name: Set tag var
+      - name: Set image variables
         id: vars
         run: |
+          echo ::set-output name=docker_path::images/wkhtmltopdf
+          echo ::set-output name=dockerfile::images/wkhtmltopdf/Dockerfile
+          echo ::set-output name=dockerdir::images/wkhtmltopdf/.
+          echo ::set-output name=hadolint_config::images/wkhtmltopdf/.hadolint.yaml
           echo ::set-output name=docker_image::docker.io/cardboardci/wkhtmltopdf
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 

--- a/.github/workflows/wkhtmltopdf.build.yml
+++ b/.github/workflows/wkhtmltopdf.build.yml
@@ -32,18 +32,18 @@ jobs:
       - name: Hadolint
         uses: docker://docker.io/cardboardci/hadolint:latest
         with:
-          args: "hadolint images/wkhtmltopdf/Dockerfile"
+          args: "hadolint --config=${{ steps.vars.outputs.hadolint_config }} ${{ steps.vars.outputs.dockerfile }}"
 
       - name: Build
         run: |
-          docker build ${{ steps.version.outputs.docker_path }}/. \
-            --file ${{ steps.version.outputs.docker_path }}/Dockerfile \
+          docker build ${{ steps.vars.outputs.dockerdir }} \
+            --file ${{ steps.vars.outputs.dockerfile }} \
             --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
 
       - name: Tests
         uses: docker://gcr.io/gcp-runtimes/container-structure-test
         with:
-          args: "test --config ${{ steps.version.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Deploy to DockerHub
         if: github.ref == 'refs/heads/master'

--- a/images/awscli/.hadolint.yaml
+++ b/images/awscli/.hadolint.yaml
@@ -1,0 +1,1 @@
+ignored:

--- a/images/bats/.hadolint.yaml
+++ b/images/bats/.hadolint.yaml
@@ -1,0 +1,1 @@
+ignored:

--- a/images/cppcheck/.hadolint.yaml
+++ b/images/cppcheck/.hadolint.yaml
@@ -1,0 +1,1 @@
+ignored:

--- a/images/ecr/.hadolint.yaml
+++ b/images/ecr/.hadolint.yaml
@@ -1,0 +1,1 @@
+ignored:

--- a/images/github/.hadolint.yaml
+++ b/images/github/.hadolint.yaml
@@ -1,0 +1,1 @@
+ignored:

--- a/images/htmlhint/.hadolint.yaml
+++ b/images/htmlhint/.hadolint.yaml
@@ -1,0 +1,1 @@
+ignored:

--- a/images/hugo/.hadolint.yaml
+++ b/images/hugo/.hadolint.yaml
@@ -1,0 +1,1 @@
+ignored:

--- a/images/latex/.hadolint.yaml
+++ b/images/latex/.hadolint.yaml
@@ -1,0 +1,1 @@
+ignored:

--- a/images/luacheck/.hadolint.yaml
+++ b/images/luacheck/.hadolint.yaml
@@ -1,0 +1,1 @@
+ignored:

--- a/images/markdownlint/.hadolint.yaml
+++ b/images/markdownlint/.hadolint.yaml
@@ -1,0 +1,1 @@
+ignored:

--- a/images/netlify/.hadolint.yaml
+++ b/images/netlify/.hadolint.yaml
@@ -1,0 +1,1 @@
+ignored:

--- a/images/pdf2htmlex/.hadolint.yaml
+++ b/images/pdf2htmlex/.hadolint.yaml
@@ -1,0 +1,1 @@
+ignored:

--- a/images/pdftools/.hadolint.yaml
+++ b/images/pdftools/.hadolint.yaml
@@ -1,0 +1,1 @@
+ignored:

--- a/images/pylint/.hadolint.yaml
+++ b/images/pylint/.hadolint.yaml
@@ -1,0 +1,1 @@
+ignored:

--- a/images/rsvg/.hadolint.yaml
+++ b/images/rsvg/.hadolint.yaml
@@ -1,0 +1,1 @@
+ignored:

--- a/images/rubocop/.hadolint.yaml
+++ b/images/rubocop/.hadolint.yaml
@@ -1,0 +1,1 @@
+ignored:

--- a/images/shellcheck/.hadolint.yaml
+++ b/images/shellcheck/.hadolint.yaml
@@ -1,0 +1,1 @@
+ignored:

--- a/images/stylelint/.hadolint.yaml
+++ b/images/stylelint/.hadolint.yaml
@@ -1,0 +1,1 @@
+ignored:

--- a/images/surge/.hadolint.yaml
+++ b/images/surge/.hadolint.yaml
@@ -1,0 +1,1 @@
+ignored:

--- a/images/svgtools/.hadolint.yaml
+++ b/images/svgtools/.hadolint.yaml
@@ -1,0 +1,1 @@
+ignored:

--- a/images/tflint/.hadolint.yaml
+++ b/images/tflint/.hadolint.yaml
@@ -1,0 +1,1 @@
+ignored:

--- a/images/wkhtmltopdf/.hadolint.yaml
+++ b/images/wkhtmltopdf/.hadolint.yaml
@@ -1,0 +1,1 @@
+ignored:


### PR DESCRIPTION
Remove the unused build variables from the workflows, and standardize the build pipeline.

This should make it easier going forward to fit the images into a more deterministic model, as each of the pipelines will be clearly defined.