### PR TITLE
Fix local path for auto-commit action

### DIFF
--- a/.github/workflows/awscli.versions.yml
+++ b/.github/workflows/awscli.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: .github/actions/auto-commit
+        uses: ./.github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/bats.versions.yml
+++ b/.github/workflows/bats.versions.yml
@@ -22,7 +22,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: .github/actions/auto-commit
+        uses: ./.github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/cppcheck.versions.yml
+++ b/.github/workflows/cppcheck.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: .github/actions/auto-commit
+        uses: ./.github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/dbxcli.versions.yml
+++ b/.github/workflows/dbxcli.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: .github/actions/auto-commit
+        uses: ./.github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/ecr.versions.yml
+++ b/.github/workflows/ecr.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: .github/actions/auto-commit
+        uses: ./.github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/github.versions.yml
+++ b/.github/workflows/github.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: .github/actions/auto-commit
+        uses: ./.github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/gitlab.versions.yml
+++ b/.github/workflows/gitlab.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: .github/actions/auto-commit
+        uses: ./.github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/hadolint.versions.yml
+++ b/.github/workflows/hadolint.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: .github/actions/auto-commit
+        uses: ./.github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/htmlhint.versions.yml
+++ b/.github/workflows/htmlhint.versions.yml
@@ -22,7 +22,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: .github/actions/auto-commit
+        uses: ./.github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/hugo.versions.yml
+++ b/.github/workflows/hugo.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: .github/actions/auto-commit
+        uses: ./.github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/latex.versions.yml
+++ b/.github/workflows/latex.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: .github/actions/auto-commit
+        uses: ./.github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/luacheck.versions.yml
+++ b/.github/workflows/luacheck.versions.yml
@@ -22,7 +22,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: .github/actions/auto-commit
+        uses: ./.github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/markdownlint.versions.yml
+++ b/.github/workflows/markdownlint.versions.yml
@@ -22,7 +22,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: .github/actions/auto-commit
+        uses: ./.github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/netlify.versions.yml
+++ b/.github/workflows/netlify.versions.yml
@@ -22,7 +22,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: .github/actions/auto-commit
+        uses: ./.github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/pdf2htmlex.versions.yml
+++ b/.github/workflows/pdf2htmlex.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: .github/actions/auto-commit
+        uses: ./.github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/pdftools.versions.yml
+++ b/.github/workflows/pdftools.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: .github/actions/auto-commit
+        uses: ./.github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/psscriptanalyzer.versions.yml
+++ b/.github/workflows/psscriptanalyzer.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: .github/actions/auto-commit
+        uses: ./.github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/pylint.versions.yml
+++ b/.github/workflows/pylint.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: .github/actions/auto-commit
+        uses: ./.github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/rsvg.versions.yml
+++ b/.github/workflows/rsvg.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: .github/actions/auto-commit
+        uses: ./.github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/rubocop.versions.yml
+++ b/.github/workflows/rubocop.versions.yml
@@ -22,7 +22,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: .github/actions/auto-commit
+        uses: ./.github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/shellcheck.versions.yml
+++ b/.github/workflows/shellcheck.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: .github/actions/auto-commit
+        uses: ./.github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/stylelint.versions.yml
+++ b/.github/workflows/stylelint.versions.yml
@@ -22,7 +22,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: .github/actions/auto-commit
+        uses: ./.github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/surge.versions.yml
+++ b/.github/workflows/surge.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: .github/actions/auto-commit
+        uses: ./.github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/svgtools.versions.yml
+++ b/.github/workflows/svgtools.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: .github/actions/auto-commit
+        uses: ./.github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/tflint.versions.yml
+++ b/.github/workflows/tflint.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: .github/actions/auto-commit
+        uses: ./.github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'

--- a/.github/workflows/wkhtmltopdf.versions.yml
+++ b/.github/workflows/wkhtmltopdf.versions.yml
@@ -21,7 +21,7 @@ jobs:
           git status
 
       - name: Commit the dependency changes
-        uses: .github/actions/auto-commit
+        uses: ./.github/actions/auto-commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: '/deps'


### PR DESCRIPTION
The path for the local reference to auto-commit is missing `./`, which is necessary to properly reference local github actions.