### PR TITLE
Upgrade all images to the monolith base image

### DIFF
--- a/images/awscli/Dockerfile
+++ b/images/awscli/Dockerfile
@@ -1,4 +1,5 @@
-FROM cardboardci/ci-core@sha256:5b93f4c8cc1ddaa809f9c27d0a865a974ccb43e5e3d38334df1b0d77ea1843fb
+ARG DIGEST=sha256:3f5fbe4b658d8cd3b7009947d1de44ca6e7fd1d25fc6723637bf5d6ab01db0c4
+FROM cardboardci/base@${DIGEST}
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/bats/Dockerfile
+++ b/images/bats/Dockerfile
@@ -1,4 +1,5 @@
-FROM cardboardci/ci-core@sha256:5b93f4c8cc1ddaa809f9c27d0a865a974ccb43e5e3d38334df1b0d77ea1843fb
+ARG DIGEST=sha256:3f5fbe4b658d8cd3b7009947d1de44ca6e7fd1d25fc6723637bf5d6ab01db0c4
+FROM cardboardci/base@${DIGEST}
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/cppcheck/Dockerfile
+++ b/images/cppcheck/Dockerfile
@@ -1,4 +1,5 @@
-FROM cardboardci/ci-core@sha256:b3e7917c28200c780e0e6a19057cb546fcafc4719640f6b8be459c390714f97c
+ARG DIGEST=sha256:3f5fbe4b658d8cd3b7009947d1de44ca6e7fd1d25fc6723637bf5d6ab01db0c4
+FROM cardboardci/base@${DIGEST}
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/dbxcli/Dockerfile
+++ b/images/dbxcli/Dockerfile
@@ -1,4 +1,5 @@
-FROM cardboardci/ci-core@sha256:5b93f4c8cc1ddaa809f9c27d0a865a974ccb43e5e3d38334df1b0d77ea1843fb
+ARG DIGEST=sha256:3f5fbe4b658d8cd3b7009947d1de44ca6e7fd1d25fc6723637bf5d6ab01db0c4
+FROM cardboardci/base@${DIGEST}
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/ecr/Dockerfile
+++ b/images/ecr/Dockerfile
@@ -1,4 +1,5 @@
-FROM cardboardci/ci-core@sha256:5b93f4c8cc1ddaa809f9c27d0a865a974ccb43e5e3d38334df1b0d77ea1843fb
+ARG DIGEST=sha256:3f5fbe4b658d8cd3b7009947d1de44ca6e7fd1d25fc6723637bf5d6ab01db0c4
+FROM cardboardci/base@${DIGEST}
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/github/Dockerfile
+++ b/images/github/Dockerfile
@@ -1,4 +1,5 @@
-FROM cardboardci/ci-core@sha256:5b93f4c8cc1ddaa809f9c27d0a865a974ccb43e5e3d38334df1b0d77ea1843fb
+ARG DIGEST=sha256:3f5fbe4b658d8cd3b7009947d1de44ca6e7fd1d25fc6723637bf5d6ab01db0c4
+FROM cardboardci/base@${DIGEST}
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/gitlab/Dockerfile
+++ b/images/gitlab/Dockerfile
@@ -1,4 +1,5 @@
-FROM cardboardci/ci-core@sha256:5b93f4c8cc1ddaa809f9c27d0a865a974ccb43e5e3d38334df1b0d77ea1843fb
+ARG DIGEST=sha256:3f5fbe4b658d8cd3b7009947d1de44ca6e7fd1d25fc6723637bf5d6ab01db0c4
+FROM cardboardci/base@${DIGEST}
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/hadolint/Dockerfile
+++ b/images/hadolint/Dockerfile
@@ -1,4 +1,5 @@
-FROM cardboardci/ci-core@sha256:5b93f4c8cc1ddaa809f9c27d0a865a974ccb43e5e3d38334df1b0d77ea1843fb
+ARG DIGEST=sha256:3f5fbe4b658d8cd3b7009947d1de44ca6e7fd1d25fc6723637bf5d6ab01db0c4
+FROM cardboardci/base@${DIGEST}
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/htmlhint/Dockerfile
+++ b/images/htmlhint/Dockerfile
@@ -1,4 +1,5 @@
-FROM cardboardci/ci-core@sha256:5b93f4c8cc1ddaa809f9c27d0a865a974ccb43e5e3d38334df1b0d77ea1843fb
+ARG DIGEST=sha256:3f5fbe4b658d8cd3b7009947d1de44ca6e7fd1d25fc6723637bf5d6ab01db0c4
+FROM cardboardci/base@${DIGEST}
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/hugo/Dockerfile
+++ b/images/hugo/Dockerfile
@@ -1,4 +1,5 @@
-FROM cardboardci/ci-core@sha256:5b93f4c8cc1ddaa809f9c27d0a865a974ccb43e5e3d38334df1b0d77ea1843fb
+ARG DIGEST=sha256:3f5fbe4b658d8cd3b7009947d1de44ca6e7fd1d25fc6723637bf5d6ab01db0c4
+FROM cardboardci/base@${DIGEST}
 USER root
 
 COPY provision/pkglist /cardboardci/pkglist

--- a/images/latex/Dockerfile
+++ b/images/latex/Dockerfile
@@ -1,4 +1,5 @@
-FROM cardboardci/ci-core@sha256:5b93f4c8cc1ddaa809f9c27d0a865a974ccb43e5e3d38334df1b0d77ea1843fb
+ARG DIGEST=sha256:3f5fbe4b658d8cd3b7009947d1de44ca6e7fd1d25fc6723637bf5d6ab01db0c4
+FROM cardboardci/base@${DIGEST}
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/luacheck/Dockerfile
+++ b/images/luacheck/Dockerfile
@@ -1,4 +1,5 @@
-FROM cardboardci/ci-core@sha256:5b93f4c8cc1ddaa809f9c27d0a865a974ccb43e5e3d38334df1b0d77ea1843fb
+ARG DIGEST=sha256:3f5fbe4b658d8cd3b7009947d1de44ca6e7fd1d25fc6723637bf5d6ab01db0c4
+FROM cardboardci/base@${DIGEST}
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/markdownlint/Dockerfile
+++ b/images/markdownlint/Dockerfile
@@ -1,4 +1,5 @@
-FROM cardboardci/ci-core@sha256:5b93f4c8cc1ddaa809f9c27d0a865a974ccb43e5e3d38334df1b0d77ea1843fb
+ARG DIGEST=sha256:3f5fbe4b658d8cd3b7009947d1de44ca6e7fd1d25fc6723637bf5d6ab01db0c4
+FROM cardboardci/base@${DIGEST}
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/netlify/Dockerfile
+++ b/images/netlify/Dockerfile
@@ -1,4 +1,5 @@
-FROM cardboardci/ci-core@sha256:b3e7917c28200c780e0e6a19057cb546fcafc4719640f6b8be459c390714f97c
+ARG DIGEST=sha256:3f5fbe4b658d8cd3b7009947d1de44ca6e7fd1d25fc6723637bf5d6ab01db0c4
+FROM cardboardci/base@${DIGEST}
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/pdf2htmlex/Dockerfile
+++ b/images/pdf2htmlex/Dockerfile
@@ -1,4 +1,5 @@
-FROM cardboardci/ci-core@sha256:b3e7917c28200c780e0e6a19057cb546fcafc4719640f6b8be459c390714f97c
+ARG DIGEST=sha256:3f5fbe4b658d8cd3b7009947d1de44ca6e7fd1d25fc6723637bf5d6ab01db0c4
+FROM cardboardci/base@${DIGEST}
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/pdftools/Dockerfile
+++ b/images/pdftools/Dockerfile
@@ -1,4 +1,5 @@
-FROM cardboardci/ci-core@sha256:5b93f4c8cc1ddaa809f9c27d0a865a974ccb43e5e3d38334df1b0d77ea1843fb
+ARG DIGEST=sha256:3f5fbe4b658d8cd3b7009947d1de44ca6e7fd1d25fc6723637bf5d6ab01db0c4
+FROM cardboardci/base@${DIGEST}
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/psscriptanalyzer/Dockerfile
+++ b/images/psscriptanalyzer/Dockerfile
@@ -1,4 +1,5 @@
-FROM cardboardci/ci-core@sha256:5b93f4c8cc1ddaa809f9c27d0a865a974ccb43e5e3d38334df1b0d77ea1843fb
+ARG DIGEST=sha256:3f5fbe4b658d8cd3b7009947d1de44ca6e7fd1d25fc6723637bf5d6ab01db0c4
+FROM cardboardci/base@${DIGEST}
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/pylint/Dockerfile
+++ b/images/pylint/Dockerfile
@@ -1,4 +1,5 @@
-FROM cardboardci/ci-core@sha256:5b93f4c8cc1ddaa809f9c27d0a865a974ccb43e5e3d38334df1b0d77ea1843fb
+ARG DIGEST=sha256:3f5fbe4b658d8cd3b7009947d1de44ca6e7fd1d25fc6723637bf5d6ab01db0c4
+FROM cardboardci/base@${DIGEST}
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/rsvg/Dockerfile
+++ b/images/rsvg/Dockerfile
@@ -1,4 +1,5 @@
-FROM cardboardci/ci-core@sha256:5b93f4c8cc1ddaa809f9c27d0a865a974ccb43e5e3d38334df1b0d77ea1843fb
+ARG DIGEST=sha256:3f5fbe4b658d8cd3b7009947d1de44ca6e7fd1d25fc6723637bf5d6ab01db0c4
+FROM cardboardci/base@${DIGEST}
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/rubocop/Dockerfile
+++ b/images/rubocop/Dockerfile
@@ -1,4 +1,5 @@
-FROM cardboardci/ci-core@sha256:5b93f4c8cc1ddaa809f9c27d0a865a974ccb43e5e3d38334df1b0d77ea1843fb
+ARG DIGEST=sha256:3f5fbe4b658d8cd3b7009947d1de44ca6e7fd1d25fc6723637bf5d6ab01db0c4
+FROM cardboardci/base@${DIGEST}
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/shellcheck/Dockerfile
+++ b/images/shellcheck/Dockerfile
@@ -1,4 +1,5 @@
-FROM cardboardci/ci-core@sha256:5b93f4c8cc1ddaa809f9c27d0a865a974ccb43e5e3d38334df1b0d77ea1843fb
+ARG DIGEST=sha256:3f5fbe4b658d8cd3b7009947d1de44ca6e7fd1d25fc6723637bf5d6ab01db0c4
+FROM cardboardci/base@${DIGEST}
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/stylelint/Dockerfile
+++ b/images/stylelint/Dockerfile
@@ -1,4 +1,5 @@
-FROM cardboardci/ci-core@sha256:5b93f4c8cc1ddaa809f9c27d0a865a974ccb43e5e3d38334df1b0d77ea1843fb
+ARG DIGEST=sha256:3f5fbe4b658d8cd3b7009947d1de44ca6e7fd1d25fc6723637bf5d6ab01db0c4
+FROM cardboardci/base@${DIGEST}
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/surge/Dockerfile
+++ b/images/surge/Dockerfile
@@ -1,4 +1,5 @@
-FROM cardboardci/ci-core@sha256:5b93f4c8cc1ddaa809f9c27d0a865a974ccb43e5e3d38334df1b0d77ea1843fb
+ARG DIGEST=sha256:3f5fbe4b658d8cd3b7009947d1de44ca6e7fd1d25fc6723637bf5d6ab01db0c4
+FROM cardboardci/base@${DIGEST}
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/svgtools/Dockerfile
+++ b/images/svgtools/Dockerfile
@@ -1,4 +1,5 @@
-FROM cardboardci/ci-core@sha256:5b93f4c8cc1ddaa809f9c27d0a865a974ccb43e5e3d38334df1b0d77ea1843fb
+ARG DIGEST=sha256:3f5fbe4b658d8cd3b7009947d1de44ca6e7fd1d25fc6723637bf5d6ab01db0c4
+FROM cardboardci/base@${DIGEST}
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/tflint/Dockerfile
+++ b/images/tflint/Dockerfile
@@ -1,4 +1,5 @@
-FROM cardboardci/ci-core@sha256:5b93f4c8cc1ddaa809f9c27d0a865a974ccb43e5e3d38334df1b0d77ea1843fb
+ARG DIGEST=sha256:3f5fbe4b658d8cd3b7009947d1de44ca6e7fd1d25fc6723637bf5d6ab01db0c4
+FROM cardboardci/base@${DIGEST}
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/images/wkhtmltopdf/Dockerfile
+++ b/images/wkhtmltopdf/Dockerfile
@@ -1,4 +1,5 @@
-FROM cardboardci/ci-core@sha256:5b93f4c8cc1ddaa809f9c27d0a865a974ccb43e5e3d38334df1b0d77ea1843fb
+ARG DIGEST=sha256:3f5fbe4b658d8cd3b7009947d1de44ca6e7fd1d25fc6723637bf5d6ab01db0c4
+FROM cardboardci/base@${DIGEST}
 USER root
 
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Switch from the original base image `ci-core` to that of `base`, which is defined in this repository.

A `digest` argument has been introduced to all dockerfiles to simplify the upgrade process. Now this line can be updated using a script, or altered for the purposes of debugging.

Additionally this upgrades all the base versions to the latest, as some of them were a bit out of date.