### PR TITLE
Bring in common deps from images to base

### DIFF
--- a/base/provision/pkglist
+++ b/base/provision/pkglist
@@ -1,3 +1,5 @@
 git=1:2.25.1-1ubuntu3
 jq=1.6-1
 curl=7.68.0-1ubuntu2
+bash=5.0-6ubuntu1
+ca-certificates=20190110ubuntu1.1


### PR DESCRIPTION
Bring the common dependencies `bash` and `ca-certificates` into the base image. This will allow for removal of these dependencies from the downstream images.