### PR TITLE
Fix entrypoint for the CardboardCI base image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -19,7 +19,7 @@ RUN bash /cardboardci/user.sh ; sync ; rm -f /cardboardci/user.sh
 
 USER ${USER}
 WORKDIR /cardboardci/workspace
-ENTRYPOINT [ "/bin/bash" ]
+ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 
 ARG version=1.0.0
 LABEL maintainer="CardboardCI"

--- a/base/tests/tests.yaml
+++ b/base/tests/tests.yaml
@@ -6,6 +6,6 @@ metadataTest:
       value: cardboardci
   exposedPorts: []
   volumes: []
-  entrypoint: ["/bin/bash"]
+  entrypoint: ["/bin/bash -l -c"]
   cmd: []
   workdir: "/cardboardci/workspace" 

--- a/base/tests/tests.yaml
+++ b/base/tests/tests.yaml
@@ -6,6 +6,5 @@ metadataTest:
       value: cardboardci
   exposedPorts: []
   volumes: []
-  entrypoint: ["/bin/bash -l -c"]
   cmd: []
   workdir: "/cardboardci/workspace" 


### PR DESCRIPTION
Fix entrypoint for the CardboardCI base image.

This can cause an issue on GitHub Actions as the `-c` argument is not supplied.