### PR TITLE
Use GitHub Container Registry to replace the packages usage

### DIFF
--- a/.github/workflows/awscli.build.yml
+++ b/.github/workflows/awscli.build.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=dockerfile::images/awscli/Dockerfile
           echo ::set-output name=dockerdir::images/awscli/.
           echo ::set-output name=hadolint_config::images/awscli/.hadolint.yaml
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/awscli
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/awscli
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -47,7 +47,7 @@ jobs:
           args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        # if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/awscli.build.yml
+++ b/.github/workflows/awscli.build.yml
@@ -47,7 +47,7 @@ jobs:
           args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
 
       - name: Push to GitHub Packages
-        # if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/awscli.build.yml
+++ b/.github/workflows/awscli.build.yml
@@ -49,5 +49,5 @@ jobs:
       - name: Push to GitHub Packages
         # if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/base.build.yml
+++ b/.github/workflows/base.build.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=dockerfile::base/Dockerfile
           echo ::set-output name=dockerdir::base/.
           echo ::set-output name=hadolint_config::base/.hadolint.yaml
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/base
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/base
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -49,5 +49,5 @@ jobs:
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/bats.build.yml
+++ b/.github/workflows/bats.build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set tag var
         id: vars
         run: |
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/bats
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/bats
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -50,5 +50,5 @@ jobs:
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/cppcheck.build.yml
+++ b/.github/workflows/cppcheck.build.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=dockerfile::images/cppcheck/Dockerfile
           echo ::set-output name=dockerdir::images/cppcheck/.
           echo ::set-output name=hadolint_config::images/cppcheck/.hadolint.yaml
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/cppcheck
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/cppcheck
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -49,5 +49,5 @@ jobs:
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/dbxcli.build.yml
+++ b/.github/workflows/dbxcli.build.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=dockerfile::images/dbxcli/Dockerfile
           echo ::set-output name=dockerdir::images/dbxcli/.
           echo ::set-output name=hadolint_config::images/dbxcli/.hadolint.yaml
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/dbxcli
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/dbxcli
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -49,5 +49,5 @@ jobs:
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/ecr.build.yml
+++ b/.github/workflows/ecr.build.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=dockerfile::images/ecr/Dockerfile
           echo ::set-output name=dockerdir::images/ecr/.
           echo ::set-output name=hadolint_config::images/ecr/.hadolint.yaml
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/ecr
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/ecr
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -49,5 +49,5 @@ jobs:
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/github.build.yml
+++ b/.github/workflows/github.build.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=dockerfile::images/github/Dockerfile
           echo ::set-output name=dockerdir::images/github/.
           echo ::set-output name=hadolint_config::images/github/.hadolint.yaml
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/github
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/github
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -49,5 +49,5 @@ jobs:
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/gitlab.build.yml
+++ b/.github/workflows/gitlab.build.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=dockerfile::images/gitlab/Dockerfile
           echo ::set-output name=dockerdir::images/gitlab/.
           echo ::set-output name=hadolint_config::images/gitlab/.hadolint.yaml
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/gitlab
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/gitlab
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -49,5 +49,5 @@ jobs:
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/hadolint.build.yml
+++ b/.github/workflows/hadolint.build.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=dockerfile::images/hadolint/Dockerfile
           echo ::set-output name=dockerdir::images/hadolint/.
           echo ::set-output name=hadolint_config::images/hadolint/.hadolint.yaml
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/hadolint
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/hadolint
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -49,5 +49,5 @@ jobs:
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/htmlhint.build.yml
+++ b/.github/workflows/htmlhint.build.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=dockerfile::images/htmlhint/Dockerfile
           echo ::set-output name=dockerdir::images/htmlhint/.
           echo ::set-output name=hadolint_config::images/htmlhint/.hadolint.yaml
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/htmlhint
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/htmlhint
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -49,5 +49,5 @@ jobs:
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/hugo.build.yml
+++ b/.github/workflows/hugo.build.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=dockerfile::images/hugo/Dockerfile
           echo ::set-output name=dockerdir::images/hugo/.
           echo ::set-output name=hadolint_config::images/hugo/.hadolint.yaml
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/hugo
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/hugo
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -49,5 +49,5 @@ jobs:
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/latex.build.yml
+++ b/.github/workflows/latex.build.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=dockerfile::images/latex/Dockerfile
           echo ::set-output name=dockerdir::images/latex/.
           echo ::set-output name=hadolint_config::images/latex/.hadolint.yaml
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/latex
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/latex
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -49,5 +49,5 @@ jobs:
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/luacheck.build.yml
+++ b/.github/workflows/luacheck.build.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=dockerfile::images/luacheck/Dockerfile
           echo ::set-output name=dockerdir::images/luacheck/.
           echo ::set-output name=hadolint_config::images/luacheck/.hadolint.yaml
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/luacheck
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/luacheck
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -49,5 +49,5 @@ jobs:
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/markdownlint.build.yml
+++ b/.github/workflows/markdownlint.build.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=dockerfile::images/markdownlint/Dockerfile
           echo ::set-output name=dockerdir::images/markdownlint/.
           echo ::set-output name=hadolint_config::images/markdownlint/.hadolint.yaml
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/markdownlint
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/markdownlint
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -49,5 +49,5 @@ jobs:
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/netlify.build.yml
+++ b/.github/workflows/netlify.build.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=dockerfile::images/netlify/Dockerfile
           echo ::set-output name=dockerdir::images/netlify/.
           echo ::set-output name=hadolint_config::images/netlify/.hadolint.yaml
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/netlify
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/netlify
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -49,5 +49,5 @@ jobs:
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/pdf2htmlex.build.yml
+++ b/.github/workflows/pdf2htmlex.build.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=dockerfile::images/pdf2htmlex/Dockerfile
           echo ::set-output name=dockerdir::images/pdf2htmlex/.
           echo ::set-output name=hadolint_config::images/pdf2htmlex/.hadolint.yaml
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/pdf2htmlex
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/pdf2htmlex
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -49,5 +49,5 @@ jobs:
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/pdftools.build.yml
+++ b/.github/workflows/pdftools.build.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=dockerfile::images/pdftools/Dockerfile
           echo ::set-output name=dockerdir::images/pdftools/.
           echo ::set-output name=hadolint_config::images/pdftools/.hadolint.yaml
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/pdftools
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/pdftools
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -49,5 +49,5 @@ jobs:
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/psscriptanalyzer.build.yml
+++ b/.github/workflows/psscriptanalyzer.build.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=dockerfile::images/psscriptanalyzer/Dockerfile
           echo ::set-output name=dockerdir::images/psscriptanalyzer/.
           echo ::set-output name=hadolint_config::images/psscriptanalyzer/.hadolint.yaml
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/psscriptanalyzer
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/psscriptanalyzer
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -49,5 +49,5 @@ jobs:
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/pylint.build.yml
+++ b/.github/workflows/pylint.build.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=dockerfile::images/pylint/Dockerfile
           echo ::set-output name=dockerdir::images/pylint/.
           echo ::set-output name=hadolint_config::images/pylint/.hadolint.yaml
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/pylint
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/pylint
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -49,5 +49,5 @@ jobs:
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/rsvg.build.yml
+++ b/.github/workflows/rsvg.build.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=dockerfile::images/rsvg/Dockerfile
           echo ::set-output name=dockerdir::images/rsvg/.
           echo ::set-output name=hadolint_config::images/rsvg/.hadolint.yaml
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/rsvg
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/rsvg
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -49,5 +49,5 @@ jobs:
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/rubocop.build.yml
+++ b/.github/workflows/rubocop.build.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=dockerfile::images/rubocop/Dockerfile
           echo ::set-output name=dockerdir::images/rubocop/.
           echo ::set-output name=hadolint_config::images/rubocop/.hadolint.yaml
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/rubocop
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/rubocop
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -49,5 +49,5 @@ jobs:
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/shellcheck.build.yml
+++ b/.github/workflows/shellcheck.build.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=dockerfile::images/shellcheck/Dockerfile
           echo ::set-output name=dockerdir::images/shellcheck/.
           echo ::set-output name=hadolint_config::images/shellcheck/.hadolint.yaml
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/shellcheck
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/shellcheck
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -49,5 +49,5 @@ jobs:
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/stylelint.build.yml
+++ b/.github/workflows/stylelint.build.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=dockerfile::images/stylelint/Dockerfile
           echo ::set-output name=dockerdir::images/stylelint/.
           echo ::set-output name=hadolint_config::images/stylelint/.hadolint.yaml
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/stylelint
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/stylelint
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -49,5 +49,5 @@ jobs:
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/surge.build.yml
+++ b/.github/workflows/surge.build.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=dockerfile::images/surge/Dockerfile
           echo ::set-output name=dockerdir::images/surge/.
           echo ::set-output name=hadolint_config::images/surge/.hadolint.yaml
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/surge
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/surge
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -49,5 +49,5 @@ jobs:
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/svgtools.build.yml
+++ b/.github/workflows/svgtools.build.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=dockerfile::images/svgtools/Dockerfile
           echo ::set-output name=dockerdir::images/svgtools/.
           echo ::set-output name=hadolint_config::images/svgtools/.hadolint.yaml
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/svgtools
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/svgtools
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -49,5 +49,5 @@ jobs:
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/tflint.build.yml
+++ b/.github/workflows/tflint.build.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=dockerfile::images/tflint/Dockerfile
           echo ::set-output name=dockerdir::images/tflint/.
           echo ::set-output name=hadolint_config::images/tflint/.hadolint.yaml
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/tflint
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/tflint
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -49,5 +49,5 @@ jobs:
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/wkhtmltopdf.build.yml
+++ b/.github/workflows/wkhtmltopdf.build.yml
@@ -27,7 +27,7 @@ jobs:
           echo ::set-output name=dockerfile::images/wkhtmltopdf/Dockerfile
           echo ::set-output name=dockerdir::images/wkhtmltopdf/.
           echo ::set-output name=hadolint_config::images/wkhtmltopdf/.hadolint.yaml
-          echo ::set-output name=docker_image::docker.pkg.github.com/cardboardci/dockerfiles/wkhtmltopdf
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/wkhtmltopdf
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
       - name: Hadolint
@@ -49,5 +49,5 @@ jobs:
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com --username ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.vars.outputs.docker_image }}


### PR DESCRIPTION
Switch to using the new `ghcr.io` for hosting the container images.

This is one of the final steps in replacing DockerHub with GitHub for the serving point of the container images. Secrets management is a bit of an issue in that it requires a github PCAT, but hopefully this will be resolved shortly to allow for use of the runners github token.

The packages will be manually cleaned up as part of this work.