### PR TITLE
Support building awscli image directly from bazel

### DIFF
--- a/images/awscli/BUILD
+++ b/images/awscli/BUILD
@@ -1,4 +1,4 @@
-load("//tools/template:docker-file.bzl", "dockerfile", "COMMON_DIGEST")
+load("//tools/template:docker-file.bzl", "dockerfile", "COMMON_DIGEST", "docker_container")
 
 dockerfile(
     name = "dockerfile",
@@ -9,4 +9,13 @@ dockerfile(
         "{summary}" : "AWS CLI",
         "{description}" : "The AWS Command Line Interface (CLI) is a unified tool to manage your AWS services",
     }
+)
+
+docker_container(
+    name = "image",
+    srcs = glob([
+        "provision/*",
+        "rootfs/*",
+    ]) + [".dockerignore"],
+    rule = "awscli",
 )

--- a/images/awscli/BUILD
+++ b/images/awscli/BUILD
@@ -1,15 +1,4 @@
-load("//tools/template:docker-file.bzl", "dockerfile", "COMMON_DIGEST", "docker_container")
-
-dockerfile(
-    name = "dockerfile",
-    image = "awscli",
-    digest = COMMON_DIGEST,
-    packages = ['apt-get'],
-    label_schema = {
-        "{summary}" : "AWS CLI",
-        "{description}" : "The AWS Command Line Interface (CLI) is a unified tool to manage your AWS services",
-    }
-)
+load("//tools/template:docker-file.bzl", "COMMON_DIGEST", "docker_container")
 
 docker_container(
     name = "image",
@@ -17,5 +6,11 @@ docker_container(
         "provision/*",
         "rootfs/*",
     ]) + [".dockerignore"],
-    rule = "awscli",
+    image = "awscli",
+    digest = COMMON_DIGEST,
+    packages = ['apt-get'],
+    label_schema = {
+        "{summary}" : "AWS CLI",
+        "{description}" : "The AWS Command Line Interface (CLI) is a unified tool to manage your AWS services",
+    }
 )


### PR DESCRIPTION
Support building the generated dockerfile from bazel for the AWSCLI image.

This does leave the option of removing the `Dockerfile` from the source, and just generating it on the fly. For now I'm going to keep both of them running while I explore a better package management system. Ideally the package management system than the `provision/*list` system.

Limitations of rules_docker with respect to windows prevent it from being used in this case. I am fine with that for now, as it gives a good opportunity to fiddle around with various bazel features like runfiles & genrules.