### PR TITLE
Image prototype for using rules_docker with images

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,21 +4,24 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_docker",
+    sha256 = "4521794f0fba2e20f3bf15846ab5e01d5332e587e9ce81629c7f96c793bb7036",
     strip_prefix = "rules_docker-0.14.4",
     urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.14.4/rules_docker-v0.14.4.tar.gz"],
-    sha256 = "4521794f0fba2e20f3bf15846ab5e01d5332e587e9ce81629c7f96c793bb7036",
 )
 
 load(
     "@io_bazel_rules_docker//repositories:repositories.bzl",
     container_repositories = "repositories",
 )
-
 container_repositories()
 
-load(
-    "@io_bazel_rules_docker//repositories:go_repositories.bzl",
-    container_go_deps = "go_deps",
-)
+load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
 
-container_go_deps()
+container_deps()
+
+load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", "pip_deps")
+
+pip_deps()
+
+load("//rules:images.bzl", "images")
+images()

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,0 +1,82 @@
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
+load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
+load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
+load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_commit")
+
+## Packages
+
+download_pkgs(
+    name = "pkgs_dwnld",
+    image_tar = "@ubuntu//image",
+    packages = [
+        "python3",
+        "python3-pip",
+    ],
+)
+
+install_pkgs(
+    name = "pkgs",
+    image_tar = "@ubuntu//image",
+    installables_tar = ":pkgs_dwnld.tar",
+    installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
+    output_image_name = "pkgs",
+)
+
+## Container
+
+container_image(
+    name = "pip_install",
+    base = ":pkgs.tar",
+    cmd = "",
+    entrypoint = "",
+)
+
+container_run_and_commit(
+    name = "awscli_install",
+    commands = [
+        "python3 -m pip install --upgrade pip setuptools wheel",
+        "python3 -m pip install awscli",
+    ],
+    image = ":pip_install.tar",
+)
+
+container_image(
+    name = "awscli",
+    base = ":awscli_install_commit.tar",
+    env = {
+        "CARDBOARDCI_WORKSPACE": "/workspace",
+    },
+    files = glob(["image_data/*"]),
+    labels = {
+        "maintainer": "CardboardCI",
+        "org.label-schema.schema-version": "1.0",
+        "org.label-schema.name": "awscli",
+        "org.label-schema.version": "1.16",
+        "org.label-schema.release=": "CardboardCI version:1.16",
+        "org.label-schema.vendor": "cardboardci",
+        "org.label-schema.architecture": "amd64",
+        "org.label-schema.summary": "AWS CLI",
+        "org.label-schema.description": "The AWS Command Line Interface (CLI) is a unified tool to manage your AWS services",
+        "org.label-schema.url": "https://github.com/cardboardci/docker-awscli",
+        "org.label-schema.changelog-url": "https://github.com/cardboardci/docker-awscli",
+        "org.label-schema.authoritative-source-url": "https://cloud.docker.com/u/cardboardci/repository/docker/cardboardci/awscli",
+        "org.label-schema.distribution-scope": "public",
+        "org.label-schema.vcs-type": "git",
+        "org.label-schema.vcs-url": "https://github.com/cardboardci/docker-awscli",
+    },
+
+    # The path /workspace is made available for all development work
+    volumes = [
+        "/workspace",
+    ],
+    workdir = "/workspace",
+)
+
+# Tests
+
+container_test(
+    name = "awscli_test",
+    configs = ["//bazel/test_configs:command.yaml", "//bazel/test_configs:metadata.yaml"],
+    image = ":awscli",
+)

--- a/bazel/README.md
+++ b/bazel/README.md
@@ -1,0 +1,8 @@
+# Bazel
+
+Prototyping using rules_docker for building images in bazel.
+
+```bash
+bazel build //bazel:awscli
+bazel test //bazel:awscli
+```

--- a/bazel/image_data/cardboardci
+++ b/bazel/image_data/cardboardci
@@ -1,0 +1,2 @@
+SomeKeyOrSomethingGoesHere
+Maybe metadata?

--- a/bazel/test_configs/BUILD
+++ b/bazel/test_configs/BUILD
@@ -1,0 +1,1 @@
+exports_files(glob(["*.yaml"]))

--- a/bazel/test_configs/command.yaml
+++ b/bazel/test_configs/command.yaml
@@ -1,0 +1,26 @@
+schemaVersion: 2.0.0
+
+fileExistenceTests:
+  - name: "python3_test"
+    path: "/usr/bin/python3"
+    shouldExist: true
+  - name: "pip3_test"
+    path: "/usr/bin/pip3"
+    shouldExist: true
+  - name: "grep_test"
+    path: "/usr/bin/grep"
+    shouldExist: true
+
+commandTests:
+  - name: "python3_test"
+    command: "python3"
+    args: ["-V"]
+    expectedOutput: ["Python 3\\..*"]
+  - name: "pip3_test"
+    command: "pip3"
+    args: ["-V"]
+    expectedOutput: ["pip \\d+\\..*"]
+  - name: "awscli_test"
+    command: "aws"
+    args: ["--version"]
+    expectedError: ["aws-cli\\/\\d+\\..*"]

--- a/bazel/test_configs/metadata.yaml
+++ b/bazel/test_configs/metadata.yaml
@@ -1,0 +1,16 @@
+schemaVersion: 2.0.0
+
+metadataTest:
+  env:
+    - key: CARDBOARDCI_WORKSPACE
+      value: /workspace
+  labels:
+    - key: "maintainer"
+      value: "CardboardCI"
+    - key: "org.label-schema.schema-version"
+      value: "1.0"
+    - key: "org.label-schema.vendor"
+      value: "cardboardci"
+    - key: "org.label-schema.architecture"
+      value: "amd64"
+  volumes: ["/workspace"]

--- a/rules/images.bzl
+++ b/rules/images.bzl
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
+
+def images():
+    container_pull(
+        name = "ubuntu",
+        registry = "index.docker.io",
+        repository = "library/ubuntu",
+        digest = "sha256:cb6a3a1298c73e3248b6b07ef3c78a14df4bade77b4be1ad725f8f5f2785e348",
+    )


### PR DESCRIPTION
A prototype awscli image built with rules_docker instead of using dockerfiles.

The current bazel rules are based around generating a dockerfile then using a genrule to run `docker build`. With rules_docker this no longer relies on the generation of a dockerfile. 

To move this forward into the rest of the images, this will need to prove out a CI/CD strategy, wrappers to reduce redeclaration and a means of upgrade automation through buildozer.

This is now a viable option as I have established a code-server environment based on linux, which removes the issues that this previously had with no windows compatibility.