### PR TITLE
Configure the CI/CD pipeline for a bazel type build process

### DIFF
--- a/.github/workflows/bazel.build.yml
+++ b/.github/workflows/bazel.build.yml
@@ -20,20 +20,27 @@ jobs:
         run: |
           echo ::set-output name=docker_image::ghcr.io/cardboardci/bats
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
-      - name: Setup Bazel
-        uses: abhinavsingh/setup-bazel@v3
+      - name: Mount bazel cache
+        uses: actions/cache@v2
         with:
-          version: 3.5.0
+          path: "/home/runner/.cache/bazel"
+          key: bazel
+      - name: Install bazelisk
+        run: |
+          curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.6.1/bazelisk-linux-amd64"
+          mkdir -p "${GITHUB_WORKSPACE}/bin/"
+          mv bazelisk-linux-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
+          chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
       - name: Build
         run: |
           bazel build //bazel:awscli
       - name: Tests
         run: |
           bazel test //bazel:awscli_test
-      - name: Tests
+      - name: Load & Tag Image
         run: |
           bazel run //bazel:awscli
-          docker tag bazel/bazel/awscli ${{ steps.vars.outputs.docker_image }}
+          docker tag bazel/bazel:awscli ${{ steps.vars.outputs.docker_image }}
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'
         run: |

--- a/.github/workflows/bazel.build.yml
+++ b/.github/workflows/bazel.build.yml
@@ -1,0 +1,39 @@
+name: bazel-build
+on:
+  push:
+    paths:
+      - bazel/image_data/*
+      - bazel/image_data/*/*
+      - bazel/image_data/*/*/*
+      - bazel/test_configs/*
+      - bazel/test_configs/*/*
+      - bazel/BUILD
+      - .github/workflows/bazel.build.yml
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set tag var
+        id: vars
+        run: |
+          echo ::set-output name=docker_image::ghcr.io/cardboardci/bats
+          echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
+      - name: Setup Bazel
+        uses: abhinavsingh/setup-bazel@v3
+      - name: Build
+        run: |
+          bazel build //bazel:awscli
+      - name: Tests
+        run: |
+          bazel test //bazel:awscli_test
+      - name: Tests
+        run: |
+          bazel run //bazel:awscli
+          docker tag bazel/bazel/awscli ${{ steps.vars.outputs.docker_image }}
+      - name: Push to GitHub Packages
+        if: github.ref == 'refs/heads/master'
+        run: |
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
+          # docker push ${{ steps.vars.outputs.docker_image }}

--- a/.github/workflows/bazel.build.yml
+++ b/.github/workflows/bazel.build.yml
@@ -33,13 +33,13 @@ jobs:
           chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
       - name: Build
         run: |
-          bazel build //bazel:awscli
+          bazel build //bazel:image
       - name: Tests
         run: |
-          bazel test //bazel:awscli_test
+          bazel test //bazel:test
       - name: Load & Tag Image
         run: |
-          bazel run //bazel:awscli
+          bazel run //bazel:image
           docker tag bazel/bazel:awscli ${{ steps.vars.outputs.docker_image }}
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/bazel.build.yml
+++ b/.github/workflows/bazel.build.yml
@@ -22,6 +22,8 @@ jobs:
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
       - name: Setup Bazel
         uses: abhinavsingh/setup-bazel@v3
+        with:
+          version: 3.5.0
       - name: Build
         run: |
           bazel build //bazel:awscli

--- a/.github/workflows/bazel.build.yml
+++ b/.github/workflows/bazel.build.yml
@@ -40,9 +40,9 @@ jobs:
       - name: Load & Tag Image
         run: |
           bazel run //bazel:image
-          docker tag bazel/bazel:awscli ${{ steps.vars.outputs.docker_image }}
-      - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
-        run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          # docker push ${{ steps.vars.outputs.docker_image }}
+          docker tag bazel/bazel:image ${{ steps.vars.outputs.docker_image }}
+      # - name: Push to GitHub Packages
+      #   if: github.ref == 'refs/heads/master'
+      #   run: |
+      #     echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
+      #     docker push ${{ steps.vars.outputs.docker_image }}

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -42,7 +42,7 @@ container_run_and_commit(
 )
 
 container_image(
-    name = "awscli",
+    name = "image",
     base = ":awscli_install_commit.tar",
     env = {
         "CARDBOARDCI_WORKSPACE": "/workspace",
@@ -76,10 +76,10 @@ container_image(
 # Tests
 
 container_test(
-    name = "awscli_test",
+    name = "test",
     configs = [
         "//bazel/test_configs:command.yaml",
         "//bazel/test_configs:metadata.yaml",
     ],
-    image = ":awscli",
+    image = ":image",
 )

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -77,6 +77,9 @@ container_image(
 
 container_test(
     name = "awscli_test",
-    configs = ["//bazel/test_configs:command.yaml", "//bazel/test_configs:metadata.yaml"],
+    configs = [
+        "//bazel/test_configs:command.yaml",
+        "//bazel/test_configs:metadata.yaml",
+    ],
     image = ":awscli",
 )

--- a/bazel/test_configs/command.yaml
+++ b/bazel/test_configs/command.yaml
@@ -23,4 +23,4 @@ commandTests:
   - name: "awscli_test"
     command: "aws"
     args: ["--version"]
-    expectedError: ["aws-cli\\/\\d+\\..*"]
+    expectedOutput: ["aws-cli\\/\\d+\\..*"]


### PR DESCRIPTION
Configure the rules_docker bazel prototype for running in github actions.

Before rules_docker can actually be leveraged in the codebase, I need to verify that bazel can be used in github actions.