### PR TITLE
Use personal access token for commits

### DIFF
--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Upgrade the dependencies
         uses: ./.github/actions/dependencies
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_PAT_TOKEN }}
 
       - name: Changes to the environment
         run: |
@@ -26,7 +26,7 @@ jobs:
       - name: Commit all of the dependencies
         uses: ./.github/actions/auto-commit
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_PAT_TOKEN }}
           BRANCH: '/deps'
           MESSAGE: 'Upgrade packages to latest dependencies'
           PULL_REQUEST_TITLE: 'Bump image dependencies to latest'

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Upgrade the dependencies
         uses: ./.github/actions/dependencies
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CARDBOARDCI_PAT_TOKEN }}
 
       - name: Changes to the environment
         run: |
@@ -26,7 +26,7 @@ jobs:
       - name: Commit all of the dependencies
         uses: ./.github/actions/auto-commit
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CARDBOARDCI_PAT_TOKEN }}
           BRANCH: '/deps'
           MESSAGE: 'Upgrade packages to latest dependencies'
           PULL_REQUEST_TITLE: 'Bump image dependencies to latest'


### PR DESCRIPTION
Replace github-actions token with personal access token for running github actions.

GitHub Actions does not run on pull requests if the request is from a forked repository or in this case, that of the bot user `github-actions`. This switches from using the native github token in github actions to using a personal access token.

There are some risks associated with this, but for the time being while switching over to bazel this will resolve the issues with dependencies being upgraded & not build-tested.

Migrating the upgrade process over to something like a github app may permit this to be run in a better way. For the time being this change should be sufficient for getting the tests going.