### PR TITLE
Support windows development with devcontainers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM gcr.io/cloud-marketplace-containers/google/bazel

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+	"name": "Node.js",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": { }
+	},
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+	"extensions": [
+		"bazelbuild.vscode-bazel","esbenp.prettier-vscode"
+	],
+	"mounts": [
+		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind,consistency=cached"
+	],
+	"forwardPorts": [3000],
+	"postCreateCommand": "yarn install",
+}


### PR DESCRIPTION
Support windows development with devcontainers, allowing for containerized development.

The rules_docker bazel rules don't support windows that well, but devcontainers allows the containerization of the development environment. As long as the the remote containers extension is installed in visual studio, this allows for opening the repository in a bazel container.

The docker socket is mounted so the downloading of images will work with the host docker daemon.