### PR TITLE
deps(ubuntu): Upgrade the base image to latest xenial image.

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,5 +1,5 @@
-# tag: ubuntu:focal-20200319
-FROM ubuntu@sha256:8e1c1ee12a539d652c371ee2f4ee66909f4f5fd8002936d8011d958f05faf989
+# tag: ubuntu:xenial-20210114
+FROM ubuntu@sha256:0eb12402800064cd8f7ae75e9c4ce1a1b5d6b9582bbaf20c539ae19652cc46ec
 ARG DEBIAN_FRONTEND=noninteractive
 ARG USER=cardboardci
 

--- a/base/provision/pkglist
+++ b/base/provision/pkglist
@@ -1,5 +1,5 @@
 git=1:2.25.1-1ubuntu3
 jq=1.6-1
-curl=7.68.0-1ubuntu2.2
-bash=5.0-6ubuntu1.1
-ca-certificates=20190110ubuntu1.1
+curl=7.68.0-1ubuntu2
+bash=5.0-6ubuntu1
+ca-certificates=20201027ubuntu0.16.04.1

--- a/base/provision/pkglist
+++ b/base/provision/pkglist
@@ -1,5 +1,5 @@
-git=1:2.25.1-1ubuntu3
-jq=1.6-1
-curl=7.68.0-1ubuntu2
-bash=5.0-6ubuntu1
+git=1:2.7.4-0ubuntu1.9
+jq=1.5+dfsg-1ubuntu0.1
+curl=7.47.0-1ubuntu2.18
+bash=4.3-14ubuntu1.4
 ca-certificates=20201027ubuntu0.16.04.1


### PR DESCRIPTION
Upgrade ubuntu to the latest version of the base image.

This process should have an automated mechanism for upgrading to the latest version with tag and digest details.