### PR TITLE
deps(upgrader): Upgrade the base image of version upgrader

### DIFF
--- a/.github/actions/dependencies/Dockerfile
+++ b/.github/actions/dependencies/Dockerfile
@@ -25,8 +25,6 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN luarocks install luasec
-
 COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["bash", "/entrypoint.sh"]

--- a/.github/actions/dependencies/Dockerfile
+++ b/.github/actions/dependencies/Dockerfile
@@ -1,5 +1,5 @@
-# tag: ubuntu:focal-20200319
-FROM ubuntu@sha256:8e1c1ee12a539d652c371ee2f4ee66909f4f5fd8002936d8011d958f05faf989
+# tag: ubuntu:xenial-20210114
+FROM ubuntu@sha256:0eb12402800064cd8f7ae75e9c4ce1a1b5d6b9582bbaf20c539ae19652cc46ec
 
 LABEL "name"="dependencies"
 LABEL "maintainer"="Jonathan Beverly <jonathan@jrbeverly.me>"

--- a/.github/actions/dependencies/Dockerfile
+++ b/.github/actions/dependencies/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+RUN luarocks install luasec
+
 COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["bash", "/entrypoint.sh"]

--- a/.github/actions/dependencies/Dockerfile
+++ b/.github/actions/dependencies/Dockerfile
@@ -1,5 +1,5 @@
 # tag: ubuntu:xenial-20210114
-FROM ubuntu@sha256:0eb12402800064cd8f7ae75e9c4ce1a1b5d6b9582bbaf20c539ae19652cc46ec
+FROM ubuntu@sha256:edf232ee7dc18c57c063bc83533ef2c03c6dfae55a0124f7d372aed51cd1d9c8
 
 LABEL "name"="dependencies"
 LABEL "maintainer"="Jonathan Beverly <jonathan@jrbeverly.me>"

--- a/.github/actions/dependencies/entrypoint.sh
+++ b/.github/actions/dependencies/entrypoint.sh
@@ -28,9 +28,9 @@ do
 			bash tools/gem.bash ${image}
 		fi
 
-		if [ -f "${directory}/provision/lualist" ]; then
-			bash tools/luarocks.bash ${image}
-		fi
+		# if [ -f "${directory}/provision/lualist" ]; then
+		#	 bash tools/luarocks.bash ${image}
+		# fi
 
 		if [ -f "${directory}/provision/nodelist" ]; then
 			bash tools/npm.bash ${image}


### PR DESCRIPTION
Upgrade the base image of the version action, to ensure up-to-date actions.

This is likely to cause some issues with some of the older images, like `wkhtmltopdf` and `rubocop`, but those can be deprecated or brought up to spec rather than hold back upgrades.