### PR TITLE
feat(base): Leave user as root

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get update \
 COPY provision/user.sh /cardboardci/user.sh
 RUN bash /cardboardci/user.sh ; sync ; rm -f /cardboardci/user.sh
 
-USER ${USER}
 WORKDIR /cardboardci/workspace
 ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 


### PR DESCRIPTION
Let the base image remain as root user for now.