### PR TITLE
feat(awscli): Support bazel style builds for awscli

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -19,7 +19,6 @@ RUN bash /cardboardci/user.sh ; sync ; rm -f /cardboardci/user.sh
 
 USER ${USER}
 WORKDIR /cardboardci/workspace
-ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 
 ARG version=1.0.0
 LABEL maintainer="CardboardCI"

--- a/base/tests/tests.yaml
+++ b/base/tests/tests.yaml
@@ -6,5 +6,5 @@ metadataTest:
       value: cardboardci
   exposedPorts: []
   volumes: []
-  cmd: []
+  cmd: [ "/bin/bash" ]
   workdir: "/cardboardci/workspace" 

--- a/images/awscli/BUILD
+++ b/images/awscli/BUILD
@@ -4,65 +4,48 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_commit")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
-# download_pkgs(
-#     name = "apt_get_download",
-#     image_tar = "@cardboardci_base//image",
-#     packages = ["awscli=1.18.69-1ubuntu0.16.04.1"],
-# )
-container_run_and_commit(
-    name = "install_adjustments",
-    commands = [
-        "apt-get update -y",
-        "apt-get install --no-install-recommends -y -q -o Dir::Cache=\"/tmp/install\" -o Dir::Cache::archives=\".\" python3 python3-pip --download-only",
-        "which dpkg-deb",
-    ],
-    image = "@cardboardci_base//image",
-)
-
 download_pkgs(
-    name = "apt_get_download_awscli",
+    name = "apt_get_download",
     image_tar = "@cardboardci_base//image",
-    # image_tar = "@ubuntu//image",
-    packages = [
-        "python3",
-        "python3-pip",
-    ],
+    packages = ["awscli=1.18.69-1ubuntu0.16.04.1"],
 )
 
+install_pkgs(
+    name = "apt_get_installed",
+    image_tar = "@cardboardci_base//image",
+    installables_tar = ":apt_get_download.tar",
+    installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
+    output_image_name = "apt_get_installed",
+)
 
-# install_pkgs(
-#     name = "apt_get_installed",
-#     image_tar = "@cardboardci_base//image",
-#     installables_tar = ":apt_get_download.tar",
-#     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
-#     output_image_name = "apt_get_installed",
-# )
+container_image(
+    name = "image",
+    base = ":apt_get_installed.tar",
+    env = {
+        "CARDBOARDCI_WORKSPACE": "/workspace",
+    },
+    files = glob(["image_data/*"]),
+    labels = {
+        "maintainer":"CardboardCI",
+        "org.opencontainers.image.title":"awscli",
+        "org.opencontainers.image.release":"CardboardCI version:0.0.0",
+        "org.opencontainers.image.vendor":"cardboardci",
+        "org.opencontainers.image.architecture":"amd64",
+        "org.opencontainers.image.summary":"AWS CLI",
+        "org.opencontainers.image.description":" The AWS Command Line Interface (CLI) is a unified tool to manage your AWS services",
+        "org.opencontainers.image.source":"https://github.com/cardboardci/dockerfiles/images/awscli",
+    },
+    volumes = [
+        "/workspace",
+    ],
+    workdir = "/workspace",
+)
 
-# container_image(
-#     name = "image",
-#     base = ":apt_get_installed.tar",
-#     env = {
-#         "CARDBOARDCI_WORKSPACE": "/workspace",
-#     },
-#     files = glob(["image_data/*"]),
-#     labels = {
-#         "maintainer":"CardboardCI",
-#         "org.opencontainers.image.title":"awscli",
-#         "org.opencontainers.image.release":"CardboardCI version:0.0.0",
-#         "org.opencontainers.image.vendor":"cardboardci",
-#         "org.opencontainers.image.architecture":"amd64",
-#         "org.opencontainers.image.summary":"AWS CLI",
-#         "org.opencontainers.image.description":" The AWS Command Line Interface (CLI) is a unified tool to manage your AWS services",
-#         "org.opencontainers.image.source":"https://github.com/cardboardci/dockerfiles/images/awscli",
-#     },
-#     volumes = [
-#         "/workspace",
-#     ],
-#     workdir = "/workspace",
-# )
-
-# container_test(
-#     name = "test",
-#     configs = glob(["test_configs/*"]),
-#     image = ":image",
-# )
+container_test(
+    name = "test",
+    configs = [
+        "//images/awscli/test_configs:command.yaml",
+        "//images/awscli/test_configs:metadata.yaml",
+    ],
+    image = ":image",
+)

--- a/images/awscli/BUILD
+++ b/images/awscli/BUILD
@@ -1,47 +1,68 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_commit")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
-download_pkgs(
-    name = "apt_get_download",
-    image_tar = "@cardboardci_base//image",
-    packages = ["awscli=1.18.69-1ubuntu0.16.04.1"],
-)
-
-install_pkgs(
-    name = "apt_get_installed",
-    image_tar = "@cardboardci_base//image",
-    installables_tar = ":apt_get_download.tar",
-    installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
-    output_image_name = "apt_get_installed",
-)
-
-container_image(
-    name = "image",
-    base = ":apt_get_installed.tar",
-    env = {
-        "CARDBOARDCI_WORKSPACE": "/workspace",
-    },
-    files = glob(["image_data/*"]),
-    labels = {
-        "maintainer":"CardboardCI",
-        "org.opencontainers.image.title":"awscli",
-        "org.opencontainers.image.release":"CardboardCI version:0.0.0",
-        "org.opencontainers.image.vendor":"cardboardci",
-        "org.opencontainers.image.architecture":"amd64",
-        "org.opencontainers.image.summary":"AWS CLI",
-        "org.opencontainers.image.description":" The AWS Command Line Interface (CLI) is a unified tool to manage your AWS services",
-        "org.opencontainers.image.source":"https://github.com/cardboardci/dockerfiles/images/awscli",
-    },
-    volumes = [
-        "/workspace",
+# download_pkgs(
+#     name = "apt_get_download",
+#     image_tar = "@cardboardci_base//image",
+#     packages = ["awscli=1.18.69-1ubuntu0.16.04.1"],
+# )
+container_run_and_commit(
+    name = "install_adjustments",
+    commands = [
+        "apt-get update -y",
+        "apt-get install --no-install-recommends -y -q -o Dir::Cache=\"/tmp/install\" -o Dir::Cache::archives=\".\" python3 python3-pip --download-only",
+        "which dpkg-deb",
     ],
-    workdir = "/workspace",
+    image = "@cardboardci_base//image",
 )
 
-container_test(
-    name = "test",
-    configs = glob(["test_configs/*"]),
-    image = ":image",
+download_pkgs(
+    name = "apt_get_download_awscli",
+    image_tar = "@cardboardci_base//image",
+    # image_tar = "@ubuntu//image",
+    packages = [
+        "python3",
+        "python3-pip",
+    ],
 )
+
+
+# install_pkgs(
+#     name = "apt_get_installed",
+#     image_tar = "@cardboardci_base//image",
+#     installables_tar = ":apt_get_download.tar",
+#     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
+#     output_image_name = "apt_get_installed",
+# )
+
+# container_image(
+#     name = "image",
+#     base = ":apt_get_installed.tar",
+#     env = {
+#         "CARDBOARDCI_WORKSPACE": "/workspace",
+#     },
+#     files = glob(["image_data/*"]),
+#     labels = {
+#         "maintainer":"CardboardCI",
+#         "org.opencontainers.image.title":"awscli",
+#         "org.opencontainers.image.release":"CardboardCI version:0.0.0",
+#         "org.opencontainers.image.vendor":"cardboardci",
+#         "org.opencontainers.image.architecture":"amd64",
+#         "org.opencontainers.image.summary":"AWS CLI",
+#         "org.opencontainers.image.description":" The AWS Command Line Interface (CLI) is a unified tool to manage your AWS services",
+#         "org.opencontainers.image.source":"https://github.com/cardboardci/dockerfiles/images/awscli",
+#     },
+#     volumes = [
+#         "/workspace",
+#     ],
+#     workdir = "/workspace",
+# )
+
+# container_test(
+#     name = "test",
+#     configs = glob(["test_configs/*"]),
+#     image = ":image",
+# )

--- a/images/awscli/BUILD
+++ b/images/awscli/BUILD
@@ -1,16 +1,47 @@
-load("//tools/template:docker-file.bzl", "COMMON_DIGEST", "docker_container")
+load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
+load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
-docker_container(
+download_pkgs(
+    name = "apt_get_download",
+    image_tar = "@cardboardci_base//image",
+    packages = ["awscli=1.18.69-1ubuntu0.16.04.1"],
+)
+
+install_pkgs(
+    name = "apt_get_installed",
+    image_tar = "@cardboardci_base//image",
+    installables_tar = ":apt_get_download.tar",
+    installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
+    output_image_name = "apt_get_installed",
+)
+
+container_image(
     name = "image",
-    srcs = glob([
-        "provision/*",
-        "rootfs/*",
-    ]) + [".dockerignore"],
-    image = "awscli",
-    digest = COMMON_DIGEST,
-    packages = ['apt-get'],
-    label_schema = {
-        "{summary}" : "AWS CLI",
-        "{description}" : "The AWS Command Line Interface (CLI) is a unified tool to manage your AWS services",
-    }
+    base = ":apt_get_installed.tar",
+    env = {
+        "CARDBOARDCI_WORKSPACE": "/workspace",
+    },
+    files = glob(["image_data/*"]),
+    labels = {
+        "maintainer":"CardboardCI",
+        "org.opencontainers.image.title":"awscli",
+        "org.opencontainers.image.release":"CardboardCI version:0.0.0",
+        "org.opencontainers.image.vendor":"cardboardci",
+        "org.opencontainers.image.architecture":"amd64",
+        "org.opencontainers.image.summary":"AWS CLI",
+        "org.opencontainers.image.description":" The AWS Command Line Interface (CLI) is a unified tool to manage your AWS services",
+        "org.opencontainers.image.source":"https://github.com/cardboardci/dockerfiles/images/awscli",
+    },
+    volumes = [
+        "/workspace",
+    ],
+    workdir = "/workspace",
+)
+
+container_test(
+    name = "test",
+    configs = glob(["test_configs/*"]),
+    image = ":image",
 )

--- a/images/awscli/test_configs/BUILD
+++ b/images/awscli/test_configs/BUILD
@@ -1,0 +1,1 @@
+exports_files(glob(["*.yaml"]))

--- a/images/awscli/test_configs/command.yaml
+++ b/images/awscli/test_configs/command.yaml
@@ -1,0 +1,26 @@
+schemaVersion: 2.0.0
+
+fileExistenceTests:
+  - name: "python3_test"
+    path: "/usr/bin/python3"
+    shouldExist: true
+  - name: "pip3_test"
+    path: "/usr/bin/pip3"
+    shouldExist: true
+  - name: "grep_test"
+    path: "/usr/bin/grep"
+    shouldExist: true
+
+commandTests:
+  - name: "python3_test"
+    command: "python3"
+    args: ["-V"]
+    expectedOutput: ["Python 3\\..*"]
+  - name: "pip3_test"
+    command: "pip3"
+    args: ["-V"]
+    expectedOutput: ["pip \\d+\\..*"]
+  - name: "awscli_test"
+    command: "aws"
+    args: ["--version"]
+    expectedOutput: ["aws-cli\\/\\d+\\..*"]

--- a/images/awscli/test_configs/command.yaml
+++ b/images/awscli/test_configs/command.yaml
@@ -1,25 +1,6 @@
 schemaVersion: 2.0.0
 
-fileExistenceTests:
-  - name: "python3_test"
-    path: "/usr/bin/python3"
-    shouldExist: true
-  - name: "pip3_test"
-    path: "/usr/bin/pip3"
-    shouldExist: true
-  - name: "grep_test"
-    path: "/usr/bin/grep"
-    shouldExist: true
-
 commandTests:
-  - name: "python3_test"
-    command: "python3"
-    args: ["-V"]
-    expectedOutput: ["Python 3\\..*"]
-  - name: "pip3_test"
-    command: "pip3"
-    args: ["-V"]
-    expectedOutput: ["pip \\d+\\..*"]
   - name: "awscli_test"
     command: "aws"
     args: ["--version"]

--- a/images/awscli/test_configs/metadata.yaml
+++ b/images/awscli/test_configs/metadata.yaml
@@ -1,0 +1,14 @@
+schemaVersion: 2.0.0
+
+metadataTest:
+  env:
+    - key: CARDBOARDCI_WORKSPACE
+      value: /workspace
+  labels:
+    - key: "maintainer"
+      value: "CardboardCI"
+    - key: "org.opencontainers.image.vendor"
+      value: "cardboardci"
+    - key: "org.opencontainers.image.architecture"
+      value: "amd64"
+  volumes: ["/workspace"]

--- a/rules/images.bzl
+++ b/rules/images.bzl
@@ -7,3 +7,10 @@ def images():
         repository = "library/ubuntu",
         digest = "sha256:cb6a3a1298c73e3248b6b07ef3c78a14df4bade77b4be1ad725f8f5f2785e348",
     )
+
+    container_pull(
+        name = "cardboardci_base",
+        registry = "ghcr.io",
+        repository = "cardboardci/base",
+        digest = "sha256:bbf36e6f9e1ff487b92a81e0a1f5fbad9bac9453dbdd3ae6c06631e27999238c",
+    )

--- a/rules/images.bzl
+++ b/rules/images.bzl
@@ -10,7 +10,10 @@ def images():
 
     container_pull(
         name = "cardboardci_base",
-        registry = "ghcr.io",
-        repository = "cardboardci/base",
-        digest = "sha256:74be5d6438114943e76d0f4f27d2ef5b05d873f07eb9a1ccd5e4735de1d43902",
+        registry = "index.docker.io",
+        repository = "library/ubuntu",
+        digest = "sha256:edf232ee7dc18c57c063bc83533ef2c03c6dfae55a0124f7d372aed51cd1d9c8",
+        # registry = "ghcr.io",
+        # repository = "cardboardci/base",
+        # digest = "sha256:74be5d6438114943e76d0f4f27d2ef5b05d873f07eb9a1ccd5e4735de1d43902",
     )

--- a/rules/images.bzl
+++ b/rules/images.bzl
@@ -12,5 +12,5 @@ def images():
         name = "cardboardci_base",
         registry = "ghcr.io",
         repository = "cardboardci/base",
-        digest = "sha256:bbf36e6f9e1ff487b92a81e0a1f5fbad9bac9453dbdd3ae6c06631e27999238c",
+        digest = "sha256:74be5d6438114943e76d0f4f27d2ef5b05d873f07eb9a1ccd5e4735de1d43902",
     )


### PR DESCRIPTION
Support bazel style builds for the AWSCLI.

This isn't complete support for the bazel style builds, but is intended to just a starter for modelling the other images.

The intention is to replace all images with bazel, using `run_and_commit` to fill in any gaps. Then leverage codify the gaps into bazel rules.