### PR TITLE
feat(cppcheck): Switch to bazel for builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+test --test_output=all

--- a/.github/workflows/cppcheck.build.yml
+++ b/.github/workflows/cppcheck.build.yml
@@ -2,23 +2,24 @@ name: cppcheck-build
 on:
   push:
     paths:
-      - images/cppcheck/provision/*
-      - images/cppcheck/provision/*/*
-      - images/cppcheck/provision/*/*/*
-      - images/cppcheck/rootfs/*
-      - images/cppcheck/rootfs/*/*
-      - images/cppcheck/rootfs/*/*/*
-      - images/cppcheck/tests/*
-      - images/cppcheck/tests/*/*
-      - images/cppcheck/Dockerfile
-      - images/cppcheck/.hadolint.yaml
       - .github/workflows/cppcheck.build.yml
+      - images/cppcheck/image_data/**/*
+      - images/cppcheck/test_configs/**/*
+      - images/cppcheck/BUILD
 
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+
+      - name: Build
+        run: |
+          bazel build //images/cppcheck:image
+
+      - name: Test
+        run: |
+          bazel test //images/cppcheck:test
 
       - name: Set image variables
         id: vars
@@ -29,16 +30,10 @@ jobs:
           echo ::set-output name=docker_image::ghcr.io/cardboardci/cppcheck
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
-      - name: Build
+      - name: Tag Image
         run: |
-          docker build ${{ steps.vars.outputs.dockerdir }} \
-            --file ${{ steps.vars.outputs.dockerfile }} \
-            --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
-
-      - name: Tests
-        uses: docker://gcr.io/gcp-runtimes/container-structure-test
-        with:
-          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          bazel run //images/cppcheck:image
+          docker tag bazel/images/cppcheck:image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/images/cppcheck/BUILD
+++ b/images/cppcheck/BUILD
@@ -7,7 +7,13 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 download_pkgs(
     name = "apt_get_download",
     image_tar = "@cardboardci_base//image",
-    packages = ["cppcheck=1.18.69-1ubuntu0.16.04.1"],
+    packages = [
+        "build-essential=12.1ubuntu2",
+        "libpcre3-dev=2:8.38-3.1",
+        "python3=3.5.1-3",
+        "python-pygments=2.1+dfsg-1",
+        "cppcheck=1.72-1",
+    ],
 )
 
 install_pkgs(

--- a/images/cppcheck/test_configs/command.yaml
+++ b/images/cppcheck/test_configs/command.yaml
@@ -1,1 +1,7 @@
 schemaVersion: 2.0.0
+
+commandTests:
+  - name: "cppcheck_test"
+    command: "cppcheck"
+    args: ["--version"]
+    expectedOutput: ["Cppcheck \\d+\\..*"]


### PR DESCRIPTION
Switch to building the cppcheck image with bazel rather than dockerfiles.

This enables building with bazel, and adds a simple command test responsible for ensuring cppcheck is installed on the image itself.

Additionally more verbose test output has been enabled by default when working in the repository.