### PR TITLE
feat(ecr): Switch to using bazel for builds

### DIFF
--- a/.github/workflows/ecr.build.yml
+++ b/.github/workflows/ecr.build.yml
@@ -2,23 +2,24 @@ name: ecr-build
 on:
   push:
     paths:
-      - images/ecr/provision/*
-      - images/ecr/provision/*/*
-      - images/ecr/provision/*/*/*
-      - images/ecr/rootfs/*
-      - images/ecr/rootfs/*/*
-      - images/ecr/rootfs/*/*/*
-      - images/ecr/tests/*
-      - images/ecr/tests/*/*
-      - images/ecr/Dockerfile
-      - images/ecr/.hadolint.yaml
       - .github/workflows/ecr.build.yml
+      - images/ecr/image_data/**/*
+      - images/ecr/test_configs/**/*
+      - images/ecr/BUILD
 
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+
+      - name: Build
+        run: |
+          bazel build //images/ecr:image
+
+      - name: Test
+        run: |
+          bazel test //images/ecr:test
 
       - name: Set image variables
         id: vars
@@ -29,16 +30,10 @@ jobs:
           echo ::set-output name=docker_image::ghcr.io/cardboardci/ecr
           echo ::set-output name=docker_tag::$(date -u +'%Y%m%d')
 
-      - name: Build
+      - name: Tag Image
         run: |
-          docker build ${{ steps.vars.outputs.dockerdir }} \
-            --file ${{ steps.vars.outputs.dockerfile }} \
-            --tag ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }} \
-
-      - name: Tests
-        uses: docker://gcr.io/gcp-runtimes/container-structure-test
-        with:
-          args: "test --config ${{ steps.vars.outputs.docker_path }}/tests/tests.yaml --image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}"
+          bazel run //images/ecr:image
+          docker tag bazel/images/ecr:image ${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.docker_tag }}
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/images/ecr/BUILD
+++ b/images/ecr/BUILD
@@ -7,7 +7,10 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 download_pkgs(
     name = "apt_get_download",
     image_tar = "@cardboardci_base//image",
-    packages = ["ecr=1.18.69-1ubuntu0.16.04.1"],
+    packages = [
+        "awscli=1.18.69-1ubuntu0.16.04.1",
+        "docker.io=18.09.7-0ubuntu1~16.04.7",
+    ],
 )
 
 install_pkgs(


### PR DESCRIPTION
Switch the image over to using bazel for building and testing the image.

The old dockerfiles and provision resources have not yet been removed to allow mechanisms for rollback and equality comparison.