### PR TITLE
deps(base): Upgrade to focal image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,5 +1,5 @@
-# tag: ubuntu:xenial-20210114
-FROM ubuntu@sha256:edf232ee7dc18c57c063bc83533ef2c03c6dfae55a0124f7d372aed51cd1d9c8
+# tag: ubuntu:focal-20210119
+FROM ubuntu@sha256:3093096ee188f8ff4531949b8f6115af4747ec1c58858c091c8cb4579c39cc4e
 ARG DEBIAN_FRONTEND=noninteractive
 ARG USER=cardboardci
 

--- a/base/provision/pkglist
+++ b/base/provision/pkglist
@@ -1,5 +1,5 @@
 git=1:2.25.1-1ubuntu3
-jq=1.5+dfsg-1ubuntu0.1
-curl=7.47.0-1ubuntu2.18
+jq=1.6-1ubuntu0.20.04.1
+curl=7.68.0-1ubuntu2.4
 bash=5.0-6ubuntu1.1
-ca-certificates=20201027ubuntu0.16.04.1
+ca-certificates=20201027ubuntu0.20.04.1

--- a/base/provision/pkglist
+++ b/base/provision/pkglist
@@ -1,5 +1,5 @@
-git=1:2.7.4-0ubuntu1.9
+git=1:2.25.1-1ubuntu3
 jq=1.5+dfsg-1ubuntu0.1
 curl=7.47.0-1ubuntu2.18
-bash=4.3-14ubuntu1.4
+bash=5.0-6ubuntu1.1
 ca-certificates=20201027ubuntu0.16.04.1


### PR DESCRIPTION
Base image was incorrectly using xenial (16.04) rather than the latest version at focal (20.04).

This resolves this by bumping to the latest possible version.