### PR TITLE
deps(images): Bump the base image and dependencies

### DIFF
--- a/.github/workflows/awscli.build.yml
+++ b/.github/workflows/awscli.build.yml
@@ -6,6 +6,7 @@ on:
       - images/awscli/image_data/**/*
       - images/awscli/test_configs/**/*
       - images/awscli/BUILD
+      - rules/images.bzl
 
 jobs:
   build-and-test:

--- a/.github/workflows/bats.build.yml
+++ b/.github/workflows/bats.build.yml
@@ -6,6 +6,7 @@ on:
       - images/bats/image_data/**/*
       - images/bats/test_configs/**/*
       - images/bats/BUILD
+      - rules/images.bzl
 
 jobs:
   build-and-test:

--- a/.github/workflows/cppcheck.build.yml
+++ b/.github/workflows/cppcheck.build.yml
@@ -6,6 +6,7 @@ on:
       - images/cppcheck/image_data/**/*
       - images/cppcheck/test_configs/**/*
       - images/cppcheck/BUILD
+      - rules/images.bzl
 
 jobs:
   build-and-test:

--- a/.github/workflows/dbxcli.build.yml
+++ b/.github/workflows/dbxcli.build.yml
@@ -6,6 +6,7 @@ on:
       - images/dbxcli/image_data/**/*
       - images/dbxcli/test_configs/**/*
       - images/dbxcli/BUILD
+      - rules/images.bzl
 
 jobs:
   build-and-test:

--- a/.github/workflows/ecr.build.yml
+++ b/.github/workflows/ecr.build.yml
@@ -6,6 +6,7 @@ on:
       - images/ecr/image_data/**/*
       - images/ecr/test_configs/**/*
       - images/ecr/BUILD
+      - rules/images.bzl
 
 jobs:
   build-and-test:

--- a/.github/workflows/github.build.yml
+++ b/.github/workflows/github.build.yml
@@ -6,6 +6,7 @@ on:
       - images/github/image_data/**/*
       - images/github/test_configs/**/*
       - images/github/BUILD
+      - rules/images.bzl
 
 jobs:
   build-and-test:

--- a/.github/workflows/gitlab.build.yml
+++ b/.github/workflows/gitlab.build.yml
@@ -6,6 +6,7 @@ on:
       - images/gitlab/image_data/**/*
       - images/gitlab/test_configs/**/*
       - images/gitlab/BUILD
+      - rules/images.bzl
 
 jobs:
   build-and-test:

--- a/.github/workflows/hadolint.build.yml
+++ b/.github/workflows/hadolint.build.yml
@@ -6,6 +6,7 @@ on:
       - images/hadolint/image_data/**/*
       - images/hadolint/test_configs/**/*
       - images/hadolint/BUILD
+      - rules/images.bzl
 
 jobs:
   build-and-test:

--- a/.github/workflows/hugo.build.yml
+++ b/.github/workflows/hugo.build.yml
@@ -6,6 +6,7 @@ on:
       - images/hugo/image_data/**/*
       - images/hugo/test_configs/**/*
       - images/hugo/BUILD
+      - rules/images.bzl
 
 jobs:
   build-and-test:

--- a/.github/workflows/pdftools.build.yml
+++ b/.github/workflows/pdftools.build.yml
@@ -6,6 +6,7 @@ on:
       - images/pdftools/image_data/**/*
       - images/pdftools/test_configs/**/*
       - images/pdftools/BUILD
+      - rules/images.bzl
 
 jobs:
   build-and-test:

--- a/.github/workflows/psscriptanalyzer.build.yml
+++ b/.github/workflows/psscriptanalyzer.build.yml
@@ -6,6 +6,7 @@ on:
       - images/psscriptanalyzer/image_data/**/*
       - images/psscriptanalyzer/test_configs/**/*
       - images/psscriptanalyzer/BUILD
+      - rules/images.bzl
 
 jobs:
   build-and-test:

--- a/.github/workflows/pylint.build.yml
+++ b/.github/workflows/pylint.build.yml
@@ -6,6 +6,7 @@ on:
       - images/pylint/image_data/**/*
       - images/pylint/test_configs/**/*
       - images/pylint/BUILD
+      - rules/images.bzl
 
 jobs:
   build-and-test:

--- a/.github/workflows/rsvg.build.yml
+++ b/.github/workflows/rsvg.build.yml
@@ -6,6 +6,7 @@ on:
       - images/rsvg/image_data/**/*
       - images/rsvg/test_configs/**/*
       - images/rsvg/BUILD
+      - rules/images.bzl
 
 jobs:
   build-and-test:

--- a/.github/workflows/shellcheck.build.yml
+++ b/.github/workflows/shellcheck.build.yml
@@ -6,6 +6,7 @@ on:
       - images/shellcheck/image_data/**/*
       - images/shellcheck/test_configs/**/*
       - images/shellcheck/BUILD
+      - rules/images.bzl
 
 jobs:
   build-and-test:

--- a/.github/workflows/svgtools.build.yml
+++ b/.github/workflows/svgtools.build.yml
@@ -6,6 +6,7 @@ on:
       - images/svgtools/image_data/**/*
       - images/svgtools/test_configs/**/*
       - images/svgtools/BUILD
+      - rules/images.bzl
 
 jobs:
   build-and-test:

--- a/images/awscli/BUILD
+++ b/images/awscli/BUILD
@@ -7,7 +7,7 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 download_pkgs(
     name = "apt_get_download",
     image_tar = "@cardboardci_base//image",
-    packages = ["awscli=1.18.69-1ubuntu0.16.04.1"],
+    packages = ["awscli"],
 )
 
 install_pkgs(

--- a/images/bats/BUILD
+++ b/images/bats/BUILD
@@ -10,8 +10,8 @@ download_pkgs(
     name = "apt_get_download",
     image_tar = "@cardboardci_base//image",
     packages = [
-        "nodejs=4.2.6~dfsg-1ubuntu4.2",
-        "npm=3.5.2-0ubuntu4",
+        "nodejs",
+        "npm",
     ],
 )
 
@@ -33,7 +33,7 @@ container_image(
 container_run_and_commit(
     name = "npm_install",
     commands = [
-        "npm install -g -y bats@1.2.1",
+        "npm install -g -y bats",
     ],
     image = ":apt_get_installed.tar",
 )

--- a/images/cppcheck/BUILD
+++ b/images/cppcheck/BUILD
@@ -8,11 +8,11 @@ download_pkgs(
     name = "apt_get_download",
     image_tar = "@cardboardci_base//image",
     packages = [
-        "build-essential=12.1ubuntu2",
-        "libpcre3-dev=2:8.38-3.1",
-        "python3=3.5.1-3",
-        "python-pygments=2.1+dfsg-1",
-        "cppcheck=1.72-1",
+        "build-essential",
+        "libpcre3-dev",
+        "python3",
+        "python-pygments",
+        "cppcheck",
     ],
 )
 

--- a/images/dbxcli/BUILD
+++ b/images/dbxcli/BUILD
@@ -7,7 +7,7 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 download_pkgs(
     name = "apt_get_download",
     image_tar = "@cardboardci_base//image",
-    packages = ["wget=1.17.1-1ubuntu1.5"],
+    packages = ["wget"],
 )
 
 install_pkgs(

--- a/images/ecr/BUILD
+++ b/images/ecr/BUILD
@@ -8,8 +8,8 @@ download_pkgs(
     name = "apt_get_download",
     image_tar = "@cardboardci_base//image",
     packages = [
-        "awscli=1.18.69-1ubuntu0.16.04.1",
-        "docker.io=18.09.7-0ubuntu1~16.04.7",
+        "awscli",
+        "docker.io",
     ],
 )
 

--- a/images/github/BUILD
+++ b/images/github/BUILD
@@ -8,9 +8,9 @@ download_pkgs(
     name = "apt_get_download",
     image_tar = "@cardboardci_base//image",
     packages = [
-        "openssh-client=1:7.2p2-4ubuntu2.10",
-        "vim-nox=2:7.4.1689-3ubuntu1.5",
-        "wget=1.17.1-1ubuntu1.5",
+        "openssh-client",
+        "vim-nox",
+        "wget",
     ],
 )
 

--- a/images/gitlab/BUILD
+++ b/images/gitlab/BUILD
@@ -8,9 +8,9 @@ download_pkgs(
     name = "apt_get_download",
     image_tar = "@cardboardci_base//image",
     packages = [
-        "openssh-client=1:7.2p2-4ubuntu2.10",
-        "vim-nox=2:7.4.1689-3ubuntu1.5",
-        "wget=1.17.1-1ubuntu1.5",
+        "openssh-client",
+        "vim-nox",
+        "wget",
     ],
 )
 

--- a/images/hadolint/BUILD
+++ b/images/hadolint/BUILD
@@ -8,8 +8,8 @@ download_pkgs(
     name = "apt_get_download",
     image_tar = "@cardboardci_base//image",
     packages = [
-        "libgmp10=2:6.1.0+dfsg-2",
-        "wget=1.17.1-1ubuntu1.5",
+        "libgmp10",
+        "wget",
     ],
 )
 

--- a/images/hugo/BUILD
+++ b/images/hugo/BUILD
@@ -8,9 +8,9 @@ download_pkgs(
     name = "apt_get_download",
     image_tar = "@cardboardci_base//image",
     packages = [
-        "libstdc++6=5.4.0-6ubuntu1~16.04.12",
-        "python-pygments=2.1+dfsg-1",
-        "wget=1.17.1-1ubuntu1.5",
+        "libstdc++6",
+        "python-pygments",
+        "wget",
     ],
 )
 

--- a/images/pdftools/BUILD
+++ b/images/pdftools/BUILD
@@ -7,7 +7,7 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 download_pkgs(
     name = "apt_get_download",
     image_tar = "@cardboardci_base//image",
-    packages = ["poppler-utils=0.41.0-0ubuntu1.16"],
+    packages = ["poppler-utils"],
 )
 
 install_pkgs(

--- a/images/pylint/BUILD
+++ b/images/pylint/BUILD
@@ -29,8 +29,8 @@ container_image(
 container_run_and_commit(
     name = "pip_install",
     commands = [
-        "python3 -m pip install --upgrade pip==21.0 setuptools==52.0.0 wheel==0.36.2",
-        "python3 -m pip install pylint==2.4.4",
+        "python3 -m pip install --upgrade pip setuptools wheel",
+        "python3 -m pip install pylint",
     ],
     image = ":apt_get_done.tar",
 )

--- a/images/rsvg/BUILD
+++ b/images/rsvg/BUILD
@@ -7,7 +7,7 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 download_pkgs(
     name = "apt_get_download",
     image_tar = "@cardboardci_base//image",
-    packages = ["librsvg2-bin=2.40.13-3ubuntu0.2"],
+    packages = ["librsvg2-bin"],
 )
 
 install_pkgs(

--- a/images/shellcheck/BUILD
+++ b/images/shellcheck/BUILD
@@ -7,7 +7,7 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 download_pkgs(
     name = "apt_get_download",
     image_tar = "@cardboardci_base//image",
-    packages = ["shellcheck=0.3.7-5"],
+    packages = ["shellcheck"],
 )
 
 install_pkgs(

--- a/images/svgtools/BUILD
+++ b/images/svgtools/BUILD
@@ -8,8 +8,8 @@ download_pkgs(
     name = "apt_get_download",
     image_tar = "@cardboardci_base//image",
     packages = [
-        "librsvg2-bin=2.40.13-3ubuntu0.2",
-        "inkscape=0.91-7ubuntu2",
+        "librsvg2-bin",
+        "inkscape",
     ],
 )
 

--- a/rules/images.bzl
+++ b/rules/images.bzl
@@ -12,5 +12,5 @@ def images():
         name = "cardboardci_base",
         registry = "ghcr.io",
         repository = "cardboardci/base",
-        digest = "sha256:95898fc0dff94f43186942e59b9dfb39dd55256f9b943250222d58db26f23195",
+        digest = "sha256:0ce687225919e808935c00e9e0646b1fdbe5f953152b24be6ab25e4db92cc51b",
     )


### PR DESCRIPTION
Bump the base image to focal from xenial to latest ubuntu image.

Dependencies for each of the images have been updated to match the new focal version, or have the pinned version removed for the time being until it can be switched over to pinned versions.