### PR TITLE
feat(images): Use in-repo base image for builds

### DIFF
--- a/.github/workflows/build.awscli.yml
+++ b/.github/workflows/build.awscli.yml
@@ -6,7 +6,8 @@ on:
       - images/awscli/image_data/**/*
       - images/awscli/test_configs/**/*
       - images/awscli/BUILD
-      - deps/images.bzl
+      - images/base/*
+      - images/base/**/*
 
 jobs:
   build-and-test:

--- a/.github/workflows/build.bats.yml
+++ b/.github/workflows/build.bats.yml
@@ -6,7 +6,8 @@ on:
       - images/bats/image_data/**/*
       - images/bats/test_configs/**/*
       - images/bats/BUILD
-      - deps/images.bzl
+      - images/base/*
+      - images/base/**/*
 
 jobs:
   build-and-test:

--- a/.github/workflows/build.cppcheck.yml
+++ b/.github/workflows/build.cppcheck.yml
@@ -6,7 +6,8 @@ on:
       - images/cppcheck/image_data/**/*
       - images/cppcheck/test_configs/**/*
       - images/cppcheck/BUILD
-      - deps/images.bzl
+      - images/base/*
+      - images/base/**/*
 
 jobs:
   build-and-test:

--- a/.github/workflows/build.dbxcli.yml
+++ b/.github/workflows/build.dbxcli.yml
@@ -6,7 +6,8 @@ on:
       - images/dbxcli/image_data/**/*
       - images/dbxcli/test_configs/**/*
       - images/dbxcli/BUILD
-      - deps/images.bzl
+      - images/base/*
+      - images/base/**/*
 
 jobs:
   build-and-test:

--- a/.github/workflows/build.ecr.yml
+++ b/.github/workflows/build.ecr.yml
@@ -6,7 +6,8 @@ on:
       - images/ecr/image_data/**/*
       - images/ecr/test_configs/**/*
       - images/ecr/BUILD
-      - deps/images.bzl
+      - images/base/*
+      - images/base/**/*
 
 jobs:
   build-and-test:

--- a/.github/workflows/build.github.yml
+++ b/.github/workflows/build.github.yml
@@ -6,7 +6,8 @@ on:
       - images/github/image_data/**/*
       - images/github/test_configs/**/*
       - images/github/BUILD
-      - deps/images.bzl
+      - images/base/*
+      - images/base/**/*
 
 jobs:
   build-and-test:

--- a/.github/workflows/build.gitlab.yml
+++ b/.github/workflows/build.gitlab.yml
@@ -6,7 +6,8 @@ on:
       - images/gitlab/image_data/**/*
       - images/gitlab/test_configs/**/*
       - images/gitlab/BUILD
-      - deps/images.bzl
+      - images/base/*
+      - images/base/**/*
 
 jobs:
   build-and-test:

--- a/.github/workflows/build.hadolint.yml
+++ b/.github/workflows/build.hadolint.yml
@@ -6,7 +6,8 @@ on:
       - images/hadolint/image_data/**/*
       - images/hadolint/test_configs/**/*
       - images/hadolint/BUILD
-      - deps/images.bzl
+      - images/base/*
+      - images/base/**/*
 
 jobs:
   build-and-test:

--- a/.github/workflows/build.htmlhint.yml
+++ b/.github/workflows/build.htmlhint.yml
@@ -6,7 +6,8 @@ on:
       - images/htmlhint/image_data/**/*
       - images/htmlhint/test_configs/**/*
       - images/htmlhint/BUILD
-      - deps/images.bzl
+      - images/base/*
+      - images/base/**/*
 
 jobs:
   build-and-test:

--- a/.github/workflows/build.hugo.yml
+++ b/.github/workflows/build.hugo.yml
@@ -6,7 +6,8 @@ on:
       - images/hugo/image_data/**/*
       - images/hugo/test_configs/**/*
       - images/hugo/BUILD
-      - deps/images.bzl
+      - images/base/*
+      - images/base/**/*
 
 jobs:
   build-and-test:

--- a/.github/workflows/build.luacheck.yml
+++ b/.github/workflows/build.luacheck.yml
@@ -6,7 +6,8 @@ on:
       - images/luacheck/image_data/**/*
       - images/luacheck/test_configs/**/*
       - images/luacheck/BUILD
-      - deps/images.bzl
+      - images/base/*
+      - images/base/**/*
 
 jobs:
   build-and-test:

--- a/.github/workflows/build.markdownlint.yml
+++ b/.github/workflows/build.markdownlint.yml
@@ -6,7 +6,8 @@ on:
       - images/markdownlint/image_data/**/*
       - images/markdownlint/test_configs/**/*
       - images/markdownlint/BUILD
-      - deps/images.bzl
+      - images/base/*
+      - images/base/**/*
 
 jobs:
   build-and-test:

--- a/.github/workflows/build.netlify.yml
+++ b/.github/workflows/build.netlify.yml
@@ -6,7 +6,8 @@ on:
       - images/netlify/image_data/**/*
       - images/netlify/test_configs/**/*
       - images/netlify/BUILD
-      - deps/images.bzl
+      - images/base/*
+      - images/base/**/*
 
 jobs:
   build-and-test:

--- a/.github/workflows/build.pdf2htmlex.yml
+++ b/.github/workflows/build.pdf2htmlex.yml
@@ -6,6 +6,8 @@ on:
       - images/pdf2htmlex/image_data/**/*
       - images/pdf2htmlex/test_configs/**/*
       - images/pdf2htmlex/BUILD
+      - images/base/*
+      - images/base/**/*
 
 jobs:
   build-and-test:

--- a/.github/workflows/build.pdftools.yml
+++ b/.github/workflows/build.pdftools.yml
@@ -6,7 +6,8 @@ on:
       - images/pdftools/image_data/**/*
       - images/pdftools/test_configs/**/*
       - images/pdftools/BUILD
-      - deps/images.bzl
+      - images/base/*
+      - images/base/**/*
 
 jobs:
   build-and-test:

--- a/.github/workflows/build.psscriptanalyzer.yml
+++ b/.github/workflows/build.psscriptanalyzer.yml
@@ -6,7 +6,8 @@ on:
       - images/psscriptanalyzer/image_data/**/*
       - images/psscriptanalyzer/test_configs/**/*
       - images/psscriptanalyzer/BUILD
-      - deps/images.bzl
+      - images/base/*
+      - images/base/**/*
 
 jobs:
   build-and-test:

--- a/.github/workflows/build.pylint.yml
+++ b/.github/workflows/build.pylint.yml
@@ -6,7 +6,8 @@ on:
       - images/pylint/image_data/**/*
       - images/pylint/test_configs/**/*
       - images/pylint/BUILD
-      - deps/images.bzl
+      - images/base/*
+      - images/base/**/*
 
 jobs:
   build-and-test:

--- a/.github/workflows/build.rsvg.yml
+++ b/.github/workflows/build.rsvg.yml
@@ -6,7 +6,8 @@ on:
       - images/rsvg/image_data/**/*
       - images/rsvg/test_configs/**/*
       - images/rsvg/BUILD
-      - deps/images.bzl
+      - images/base/*
+      - images/base/**/*
 
 jobs:
   build-and-test:

--- a/.github/workflows/build.rubocop.yml
+++ b/.github/workflows/build.rubocop.yml
@@ -6,7 +6,8 @@ on:
       - images/rubocop/image_data/**/*
       - images/rubocop/test_configs/**/*
       - images/rubocop/BUILD
-      - deps/images.bzl
+      - images/base/*
+      - images/base/**/*
 
 jobs:
   build-and-test:

--- a/.github/workflows/build.shellcheck.yml
+++ b/.github/workflows/build.shellcheck.yml
@@ -6,7 +6,8 @@ on:
       - images/shellcheck/image_data/**/*
       - images/shellcheck/test_configs/**/*
       - images/shellcheck/BUILD
-      - deps/images.bzl
+      - images/base/*
+      - images/base/**/*
 
 jobs:
   build-and-test:

--- a/.github/workflows/build.stylelint.yml
+++ b/.github/workflows/build.stylelint.yml
@@ -6,7 +6,8 @@ on:
       - images/stylelint/image_data/**/*
       - images/stylelint/test_configs/**/*
       - images/stylelint/BUILD
-      - deps/images.bzl
+      - images/base/*
+      - images/base/**/*
 
 jobs:
   build-and-test:

--- a/.github/workflows/build.surge.yml
+++ b/.github/workflows/build.surge.yml
@@ -6,7 +6,8 @@ on:
       - images/surge/image_data/**/*
       - images/surge/test_configs/**/*
       - images/surge/BUILD
-      - deps/images.bzl
+      - images/base/*
+      - images/base/**/*
 
 jobs:
   build-and-test:

--- a/.github/workflows/build.svgtools.yml
+++ b/.github/workflows/build.svgtools.yml
@@ -6,7 +6,8 @@ on:
       - images/svgtools/image_data/**/*
       - images/svgtools/test_configs/**/*
       - images/svgtools/BUILD
-      - deps/images.bzl
+      - images/base/*
+      - images/base/**/*
 
 jobs:
   build-and-test:

--- a/.github/workflows/build.tflint.yml
+++ b/.github/workflows/build.tflint.yml
@@ -6,7 +6,8 @@ on:
       - images/tflint/image_data/**/*
       - images/tflint/test_configs/**/*
       - images/tflint/BUILD
-      - deps/images.bzl
+      - images/base/*
+      - images/base/**/*
 
 jobs:
   build-and-test:

--- a/.github/workflows/build.wkhtmltopdf.yml
+++ b/.github/workflows/build.wkhtmltopdf.yml
@@ -6,7 +6,8 @@ on:
       - images/wkhtmltopdf/image_data/**/*
       - images/wkhtmltopdf/test_configs/**/*
       - images/wkhtmltopdf/BUILD
-      - deps/images.bzl
+      - images/base/*
+      - images/base/**/*
 
 jobs:
   build-and-test:

--- a/deps/images.bzl
+++ b/deps/images.bzl
@@ -2,13 +2,6 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 
 def images():
     container_pull(
-        name = "cardboardci_base",
-        registry = "ghcr.io",
-        repository = "cardboardci/base",
-        digest = "sha256:0ce687225919e808935c00e9e0646b1fdbe5f953152b24be6ab25e4db92cc51b",
-    )
-
-    container_pull(
         name = "ubuntu",
         registry = "index.docker.io",
         repository = "library/ubuntu",

--- a/images/awscli/BUILD
+++ b/images/awscli/BUILD
@@ -6,13 +6,13 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 download_pkgs(
     name = "apt_get_download",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     packages = ["awscli"],
 )
 
 install_pkgs(
     name = "apt_get_installed",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     installables_tar = ":apt_get_download.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "apt_get_installed",

--- a/images/base/BUILD
+++ b/images/base/BUILD
@@ -4,23 +4,9 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_commit")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
-# TODO: Pinned versions to avoid bad version upgrades
-# This just ensures that the base official image is upgraded to latest for packages
-# Ideally this would pin the package versions of the official version, then upgrade on-demand
-container_run_and_commit(
-    name = "upgraded_base",
-    commands = [
-        "apt-get update -y",
-        "apt-get upgrade -y",
-        "apt-get clean",
-        "rm -rf /var/lib/apt/lists/*"
-    ],
-    image = "@ubuntu//image",
-)
-
 download_pkgs(
     name = "apt_get_download",
-    image_tar = ":upgraded_base_commit.tar",
+    image_tar = "@ubuntu//image",
     packages = [
         "git",
         "jq",
@@ -32,7 +18,7 @@ download_pkgs(
 
 install_pkgs(
     name = "apt_get_installed",
-    image_tar = ":upgraded_base_commit.tar",
+    image_tar = "@ubuntu//image",
     installables_tar = ":apt_get_download.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "apt_get_installed",

--- a/images/bats/BUILD
+++ b/images/bats/BUILD
@@ -8,7 +8,7 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 download_pkgs(
     name = "apt_get_download",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     packages = [
         "nodejs",
         "npm",
@@ -17,7 +17,7 @@ download_pkgs(
 
 install_pkgs(
     name = "apt_get_install",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     installables_tar = ":apt_get_download.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "apt_get_install",

--- a/images/cppcheck/BUILD
+++ b/images/cppcheck/BUILD
@@ -6,7 +6,7 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 download_pkgs(
     name = "apt_get_download",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     packages = [
         "build-essential",
         "libpcre3-dev",
@@ -18,7 +18,7 @@ download_pkgs(
 
 install_pkgs(
     name = "apt_get_installed",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     installables_tar = ":apt_get_download.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "apt_get_installed",

--- a/images/dbxcli/BUILD
+++ b/images/dbxcli/BUILD
@@ -6,13 +6,13 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 download_pkgs(
     name = "apt_get_download",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     packages = ["wget"],
 )
 
 install_pkgs(
     name = "apt_get_installed",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     installables_tar = ":apt_get_download.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "apt_get_installed",

--- a/images/ecr/BUILD
+++ b/images/ecr/BUILD
@@ -6,7 +6,7 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 download_pkgs(
     name = "apt_get_download",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     packages = [
         "awscli",
         "docker.io",
@@ -15,7 +15,7 @@ download_pkgs(
 
 install_pkgs(
     name = "apt_get_installed",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     installables_tar = ":apt_get_download.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "apt_get_installed",

--- a/images/github/BUILD
+++ b/images/github/BUILD
@@ -6,7 +6,7 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 download_pkgs(
     name = "apt_get_download",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     packages = [
         "openssh-client",
         "vim-nox",
@@ -16,7 +16,7 @@ download_pkgs(
 
 install_pkgs(
     name = "apt_get_installed",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     installables_tar = ":apt_get_download.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "apt_get_installed",

--- a/images/gitlab/BUILD
+++ b/images/gitlab/BUILD
@@ -6,7 +6,7 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 download_pkgs(
     name = "apt_get_download",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     packages = [
         "openssh-client",
         "vim-nox",
@@ -16,7 +16,7 @@ download_pkgs(
 
 install_pkgs(
     name = "apt_get_installed",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     installables_tar = ":apt_get_download.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "apt_get_installed",

--- a/images/hadolint/BUILD
+++ b/images/hadolint/BUILD
@@ -6,7 +6,7 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 download_pkgs(
     name = "apt_get_download",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     packages = [
         "libgmp10",
         "wget",
@@ -15,7 +15,7 @@ download_pkgs(
 
 install_pkgs(
     name = "apt_get_installed",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     installables_tar = ":apt_get_download.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "apt_get_installed",

--- a/images/htmlhint/BUILD
+++ b/images/htmlhint/BUILD
@@ -6,7 +6,7 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 download_pkgs(
     name = "apt_get_download",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     packages = [
         "nodejs",
         "npm",
@@ -15,7 +15,7 @@ download_pkgs(
 
 install_pkgs(
     name = "apt_get_installed",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     installables_tar = ":apt_get_download.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "apt_get_installed",

--- a/images/hugo/BUILD
+++ b/images/hugo/BUILD
@@ -6,7 +6,7 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 download_pkgs(
     name = "apt_get_download",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     packages = [
         "libstdc++6",
         "python-pygments",
@@ -16,7 +16,7 @@ download_pkgs(
 
 install_pkgs(
     name = "apt_get_installed",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     installables_tar = ":apt_get_download.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "apt_get_installed",

--- a/images/luacheck/BUILD
+++ b/images/luacheck/BUILD
@@ -6,7 +6,7 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 download_pkgs(
     name = "apt_get_download",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     packages = [
         "luarocks",
         "lua-sec",
@@ -16,7 +16,7 @@ download_pkgs(
 
 install_pkgs(
     name = "apt_get_installed",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     installables_tar = ":apt_get_download.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "apt_get_installed",

--- a/images/markdownlint/BUILD
+++ b/images/markdownlint/BUILD
@@ -6,7 +6,7 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 download_pkgs(
     name = "apt_get_download",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     packages = [
         "nodejs",
         "npm",
@@ -15,7 +15,7 @@ download_pkgs(
 
 install_pkgs(
     name = "apt_get_installed",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     installables_tar = ":apt_get_download.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "apt_get_installed",

--- a/images/netlify/BUILD
+++ b/images/netlify/BUILD
@@ -7,7 +7,7 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 download_pkgs(
     name = "apt_get_download",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     packages = [
         "nodejs",
         "npm",
@@ -16,7 +16,7 @@ download_pkgs(
 
 install_pkgs(
     name = "apt_get_installed",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     installables_tar = ":apt_get_download.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "apt_get_installed",

--- a/images/pdf2htmlex/BUILD
+++ b/images/pdf2htmlex/BUILD
@@ -6,7 +6,7 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 download_pkgs(
     name = "apt_get_download",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     packages = [
         "cmake",
         "autotools-dev",
@@ -33,7 +33,7 @@ download_pkgs(
 
 install_pkgs(
     name = "apt_get_installed",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     installables_tar = ":apt_get_download.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "apt_get_installed",

--- a/images/pdftools/BUILD
+++ b/images/pdftools/BUILD
@@ -6,13 +6,13 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 download_pkgs(
     name = "apt_get_download",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     packages = ["poppler-utils"],
 )
 
 install_pkgs(
     name = "apt_get_installed",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     installables_tar = ":apt_get_download.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "apt_get_installed",

--- a/images/psscriptanalyzer/BUILD
+++ b/images/psscriptanalyzer/BUILD
@@ -6,7 +6,7 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 download_pkgs(
     name = "apt_get_download",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     packages = [
         "wget",
         "liblttng-ust0",
@@ -25,7 +25,7 @@ download_pkgs(
 
 install_pkgs(
     name = "apt_get_installed",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     installables_tar = ":apt_get_download.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "apt_get_installed",

--- a/images/rsvg/BUILD
+++ b/images/rsvg/BUILD
@@ -6,13 +6,13 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 download_pkgs(
     name = "apt_get_download",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     packages = ["librsvg2-bin"],
 )
 
 install_pkgs(
     name = "apt_get_installed",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     installables_tar = ":apt_get_download.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "apt_get_installed",

--- a/images/rubocop/BUILD
+++ b/images/rubocop/BUILD
@@ -6,7 +6,7 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 download_pkgs(
     name = "apt_get_download",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     packages = [
         "ruby2.7",
     ],
@@ -14,7 +14,7 @@ download_pkgs(
 
 install_pkgs(
     name = "apt_get_installed",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     installables_tar = ":apt_get_download.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "apt_get_installed",

--- a/images/shellcheck/BUILD
+++ b/images/shellcheck/BUILD
@@ -6,13 +6,13 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 download_pkgs(
     name = "apt_get_download",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     packages = ["shellcheck"],
 )
 
 install_pkgs(
     name = "apt_get_installed",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     installables_tar = ":apt_get_download.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "apt_get_installed",

--- a/images/stylelint/BUILD
+++ b/images/stylelint/BUILD
@@ -6,7 +6,7 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 download_pkgs(
     name = "apt_get_download",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     packages = [
         "nodejs",
         "npm",
@@ -15,7 +15,7 @@ download_pkgs(
 
 install_pkgs(
     name = "apt_get_installed",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     installables_tar = ":apt_get_download.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "apt_get_installed",

--- a/images/surge/BUILD
+++ b/images/surge/BUILD
@@ -6,7 +6,7 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 download_pkgs(
     name = "apt_get_download",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     packages = [
         "nodejs",
         "npm",
@@ -15,7 +15,7 @@ download_pkgs(
 
 install_pkgs(
     name = "apt_get_installed",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     installables_tar = ":apt_get_download.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "apt_get_installed",

--- a/images/svgtools/BUILD
+++ b/images/svgtools/BUILD
@@ -6,7 +6,7 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 download_pkgs(
     name = "apt_get_download",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     packages = [
         "librsvg2-bin",
         "inkscape",
@@ -15,7 +15,7 @@ download_pkgs(
 
 install_pkgs(
     name = "apt_get_installed",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     installables_tar = ":apt_get_download.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "apt_get_installed",

--- a/images/tflint/BUILD
+++ b/images/tflint/BUILD
@@ -6,7 +6,7 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 download_pkgs(
     name = "apt_get_download",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     packages = [
         "curl",
         "unzip",
@@ -15,7 +15,7 @@ download_pkgs(
 
 install_pkgs(
     name = "apt_get_installed",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     installables_tar = ":apt_get_download.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "apt_get_installed",

--- a/images/wkhtmltopdf/BUILD
+++ b/images/wkhtmltopdf/BUILD
@@ -6,7 +6,7 @@ load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 download_pkgs(
     name = "apt_get_download",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     packages = [
         "openssl",
         "build-essential",
@@ -27,7 +27,7 @@ download_pkgs(
 
 install_pkgs(
     name = "apt_get_installed",
-    image_tar = "@cardboardci_base//image",
+    image_tar = "//images/base:image.tar",
     installables_tar = ":apt_get_download.tar",
     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
     output_image_name = "apt_get_installed",


### PR DESCRIPTION
Convert images to use in-repo base image, rather than prebuilt external.

This helps make the development process easier as it no longer relies on two different changes when bumping the base image. Any change to the base image can be used as a means to trigger an update on all of the images, and confirm they work as expected.