### PR TITLE
feat(website): Inline website repository into dockerfiles

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install and Build
         uses: docker://squidfunk/mkdocs-material@sha256:5282540ecb411db49a2ae3ccea3b00a0ab1f55ecd8151e2941cf0ccad69d2beb
         with:
-          args: "build --help"
+          args: "build --config-file docs/mkdocs.yml --site-dir docs/public"
       # - name: Deploy
       #   uses: JamesIves/github-pages-deploy-action@releases/v3
       #   with:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -16,14 +16,10 @@ jobs:
         uses: docker://squidfunk/mkdocs-material@sha256:5282540ecb411db49a2ae3ccea3b00a0ab1f55ecd8151e2941cf0ccad69d2beb
         with:
           args: "build --config-file docs/mkdocs.yml --site-dir public"
-      - name: Install buildozer
-        run: |
-          ls 
-          ls docs/
-          ls docs/public/
-      # - name: Deploy
-      #   uses: JamesIves/github-pages-deploy-action@releases/v3
-      #   with:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     BRANCH: gh-pages
-      #     FOLDER: docs/public
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        # if: github.ref == 'refs/heads/master'
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: docs/public

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -12,10 +12,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install and Build
+      - name: Mkdocs
         uses: docker://squidfunk/mkdocs-material@sha256:5282540ecb411db49a2ae3ccea3b00a0ab1f55ecd8151e2941cf0ccad69d2beb
         with:
-          args: "build --config-file docs/mkdocs.yml --site-dir docs/public"
+          args: "build --config-file docs/mkdocs.yml --site-dir public"
+      - name: Install buildozer
+        run: |
+          ls 
+          ls docs/
+          ls docs/public/
       # - name: Deploy
       #   uses: JamesIves/github-pages-deploy-action@releases/v3
       #   with:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,0 +1,24 @@
+name: "Build and Deploy"
+on:
+  push:
+    paths:
+      - .github/workflows/website.yml
+      - docs/*
+      - docs/**/*
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install and Build
+        uses: docker://squidfunk/mkdocs-material@sha256:5282540ecb411db49a2ae3ccea3b00a0ab1f55ecd8151e2941cf0ccad69d2beb
+        with:
+          args: "build --help"
+      # - name: Deploy
+      #   uses: JamesIves/github-pages-deploy-action@releases/v3
+      #   with:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #     BRANCH: gh-pages
+      #     FOLDER: docs/public

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,0 +1,20 @@
+# Project information
+site_name: 'CardboardCI'
+site_description: 'Temporary website for CardboardCI.'
+site_author: 'Jonathan Beverly'
+site_dir: public
+docs_dir: www
+
+theme:
+  name: 'material'
+  language: 'en'
+  palette:
+    primary: 'white'
+    accent: 'indigo'
+
+extra:
+  search:
+    language: 'en'
+  social:
+    - type: 'github'
+      link: 'https://github.com/cardboardci'

--- a/docs/public/CNAME
+++ b/docs/public/CNAME
@@ -1,0 +1,1 @@
+cardboardci.jrbeverly.me

--- a/docs/www/README.md
+++ b/docs/www/README.md
@@ -1,0 +1,18 @@
+# CardboardCI
+
+A collection of docker images that provide a common core for use in continuous integration.
+
+The idea of these images is to balance the following:
+
+- Frequency of updates
+- Standard set of tooling
+- Common Environment
+
+## Status
+
+I have just recently moved the project from GitLab to GitHub, and I am in the process of enabling GitHub Actions for all of the docker images. In the future I'd like for it to:
+
+- Update the dependencies automatically
+- Have sufficient documentation for each image (and how to use)
+- Tests to verify that each image works
+- Samples that verify each image is working as intended

--- a/docs/www/README.md
+++ b/docs/www/README.md
@@ -10,9 +10,9 @@ The idea of these images is to balance the following:
 
 ## Status
 
-I have just recently moved the project from GitLab to GitHub, and I am in the process of enabling GitHub Actions for all of the docker images. In the future I'd like for it to:
+Project is still is progress, documentation is lacking, progress will evolve over time. Aims as below:
 
-- Update the dependencies automatically
-- Have sufficient documentation for each image (and how to use)
-- Tests to verify that each image works
-- Samples that verify each image is working as intended
+- Dependencies are pinned
+- Dependencies are updated automatically by GitHub Actions
+- Images have basic documentation for common usages (GitHub Actions / etc)
+- Tests verifying aspects of each image (/tmp empty, metadata set)

--- a/docs/www/core.md
+++ b/docs/www/core.md
@@ -1,0 +1,9 @@
+# Common Base Image
+
+The docker image `ci-core` acts as the common base for all of the images.
+
+This image allows:
+
+- Running as non-root user
+- All base dependencies are at latest
+- Standard set of tools for use in CI

--- a/docs/www/images/bats.md
+++ b/docs/www/images/bats.md
@@ -1,0 +1,3 @@
+# Bats
+
+Bats is a TAP-compliant testing framework for Bash. It provides a simple way to verify that the UNIX programs you write behave as expected.

--- a/docs/www/images/cppcheck.md
+++ b/docs/www/images/cppcheck.md
@@ -1,0 +1,3 @@
+# CppCheck
+
+Cppcheck is a static analysis tool for C/C++ code. It provides unique code analysis to detect bugs and focuses on detecting undefined behaviour and dangerous coding constructs. The goal is to detect only real errors in the code (i.e. have very few false positives).

--- a/docs/www/images/dbxcli.md
+++ b/docs/www/images/dbxcli.md
@@ -1,0 +1,3 @@
+# DropboxCLI
+
+The DropboxCLI contained in a docker image.

--- a/docs/www/images/ecr.md
+++ b/docs/www/images/ecr.md
@@ -1,0 +1,3 @@
+# AWSCLI with Docker (ECR)
+
+Containerized AWS CLI on a docker image to allow for building and deploying of docker images onto ECR.

--- a/docs/www/images/github.md
+++ b/docs/www/images/github.md
@@ -1,0 +1,3 @@
+# GitHub
+
+The GitHubCLI for interacting with GitHub.

--- a/docs/www/images/gitlab.md
+++ b/docs/www/images/gitlab.md
@@ -1,0 +1,3 @@
+# GitLab
+
+The GitLabCLI for interacting with Gitlab.

--- a/docs/www/images/hadolint.md
+++ b/docs/www/images/hadolint.md
@@ -1,0 +1,3 @@
+# HadoLint
+
+Dockerfile linter, validate inline bash, written in Haskell

--- a/docs/www/images/htmlhint.md
+++ b/docs/www/images/htmlhint.md
@@ -1,0 +1,3 @@
+# HTML
+
+The static code analysis tool you need for your HTML 

--- a/docs/www/images/hugo.md
+++ b/docs/www/images/hugo.md
@@ -1,0 +1,3 @@
+# Hugo
+
+Hugo is one of the most popular open-source static site generators. With its amazing speed and flexibility, Hugo makes building websites fun again.

--- a/docs/www/images/latex.md
+++ b/docs/www/images/latex.md
@@ -1,0 +1,3 @@
+# LaTeX
+
+LaTeX is a high-quality typesetting system; it includes features designed for the production of technical and scientific documentation. LaTeX is the de facto standard for the communication and publication of scientific documents.

--- a/docs/www/images/latex.md
+++ b/docs/www/images/latex.md
@@ -1,3 +1,0 @@
-# LaTeX
-
-LaTeX is a high-quality typesetting system; it includes features designed for the production of technical and scientific documentation. LaTeX is the de facto standard for the communication and publication of scientific documents.

--- a/docs/www/images/luacheck.md
+++ b/docs/www/images/luacheck.md
@@ -1,0 +1,3 @@
+# LuaCheck
+
+Luacheck is a static analyzer and a linter for Lua. Luacheck detects various issues such as usage of undefined global variables, unused variables and values, accessing uninitialized variables, unreachable code and more. Most aspects of checking are configurable: there are options for defining custom project-related globals, for selecting set of standard globals (version of Lua standard library), for filtering warnings by type and name of related variable, etc. The options can be used on the command line, put into a config or directly into checked files as Lua comments.

--- a/docs/www/images/markdownlint.md
+++ b/docs/www/images/markdownlint.md
@@ -1,0 +1,3 @@
+# MarkdownLint
+
+The Markdown markup language is designed to be easy to read, write, and understand. It succeeds - and its flexibility is both a benefit and a drawback. Many styles are possible, so formatting can be inconsistent. Some constructs don't work well in all parsers and should be avoided. The CommonMark specification standardizes parsers - but not authors.

--- a/docs/www/images/pdf2htmlex.md
+++ b/docs/www/images/pdf2htmlex.md
@@ -1,0 +1,3 @@
+# Pdf2HtmlEX
+
+pdf2htmlEX renders PDF files in HTML, utilizing modern Web technologies. Academic papers with lots of formulas and figures? Magazines with complicated layouts? No problem!

--- a/docs/www/images/pdftools.md
+++ b/docs/www/images/pdftools.md
@@ -1,0 +1,3 @@
+# PDF Tools
+
+PDF Tools is a bundle of programs that can work with pdf files.

--- a/docs/www/images/psscriptanalyzer.md
+++ b/docs/www/images/psscriptanalyzer.md
@@ -1,0 +1,3 @@
+# PSScriptAnalyzer
+
+PSScriptAnalyzer is a static code checker for Windows PowerShell modules and scripts. PSScriptAnalyzer checks the quality of Windows PowerShell code by running a set of rules. The rules are based on PowerShell best practices identified by PowerShell Team and the community. It generates DiagnosticResults (errors and warnings) to inform users about potential code defects and suggests possible solutions for improvements.

--- a/docs/www/images/pylint.md
+++ b/docs/www/images/pylint.md
@@ -1,0 +1,3 @@
+# PyLint
+
+Pylint is a Python static code analysis tool which looks for programming errors, helps enforcing a coding standard, sniffs for code smells and offers simple refactoring suggestions.

--- a/docs/www/images/rsvg.md
+++ b/docs/www/images/rsvg.md
@@ -1,0 +1,3 @@
+# RSvg
+
+A bundle of programs for rasterizing SVG files.

--- a/docs/www/images/rubocop.md
+++ b/docs/www/images/rubocop.md
@@ -1,0 +1,3 @@
+# Rubocop
+
+RuboCop is a Ruby static code analyzer and code formatter. Out of the box it will enforce many of the guidelines outlined in the community Ruby Style Guide.

--- a/docs/www/images/shellcheck.md
+++ b/docs/www/images/shellcheck.md
@@ -1,0 +1,3 @@
+# Shellcheck
+
+ShellCheck is an open source static anaylsis tool that automatically finds bugs in your shell scripts.

--- a/docs/www/images/stylelint.md
+++ b/docs/www/images/stylelint.md
@@ -1,0 +1,3 @@
+# Stylelint
+
+A mighty, modern linter that helps you avoid errors and enforce conventions in your styles.

--- a/docs/www/images/surge.md
+++ b/docs/www/images/surge.md
@@ -1,0 +1,3 @@
+# Surge.sh
+
+This is the CLI client for the surge.sh hosted service.

--- a/docs/www/images/svgtools.md
+++ b/docs/www/images/svgtools.md
@@ -1,0 +1,3 @@
+# SVGTools
+
+SVG Tools is a bundle of programs that can work with SVG files.

--- a/docs/www/images/tflint.md
+++ b/docs/www/images/tflint.md
@@ -1,0 +1,3 @@
+# TfLint
+
+TFLint is a Terraform linter focused on possible errors, best practices, etc.


### PR DESCRIPTION
Inline the website repository into the project, removing the old website repository.

This inlines the documentation of the website repository into the project, creating the website on the domain `cardboardci.jrbeverly.me`. The site is hosted by GitHub Actions.

Additionally this will simplify the process of listing tags and other components when constructing the site, as the identifiers for the images will be available in-source.