### PR TITLE
fix(upgrade): Remove path trigger on workflows

### DIFF
--- a/.github/workflows/upgrader.base.yml
+++ b/.github/workflows/upgrader.base.yml
@@ -3,7 +3,7 @@ name: dependecy-imagebase
 on:
   schedule:
     - cron: "30 4 6 * *"
-  trigger:
+  workflow_dispatch:
 
 jobs:
   image-upgrade:

--- a/.github/workflows/upgrader.base.yml
+++ b/.github/workflows/upgrader.base.yml
@@ -3,10 +3,7 @@ name: dependecy-imagebase
 on:
   schedule:
     - cron: "30 4 6 * *"
-  push:
-    paths:
-      - .github/workflows/upgrader.base.yml
-      - .github/actions/docker-hub-image-digest/*
+  trigger:
 
 jobs:
   image-upgrade:


### PR DESCRIPTION
Remove path trigger from workflows as it creates confusion when making edits.

Workflows that are able to commit against the repository should only be triggered by schedule or manually dispatched.