### PR TITLE
feat(labels): Add labels for user/group and URL to docs

### DIFF
--- a/images/awscli/BUILD
+++ b/images/awscli/BUILD
@@ -2,6 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -36,9 +37,9 @@ container_image(
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/awscli",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
         "org.cardboardci.image.user": "cardboardci",
-        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.uid": CARDBOARDCI_UID,
         "org.cardboardci.image.group": "cardboardci",
-        "org.cardboardci.image.gid": "180000",
+        "org.cardboardci.image.gid": CARDBOARDCI_GID,
     },
     user = "cardboardci",
     volumes = [

--- a/images/awscli/BUILD
+++ b/images/awscli/BUILD
@@ -33,6 +33,8 @@ container_image(
         "org.opencontainers.image.summary": "AWS CLI",
         "org.opencontainers.image.description": " The AWS Command Line Interface (CLI) is a unified tool to manage your AWS services",
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/awscli",
+        "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/awscli",
+        "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
     },
     user = "cardboardci",
     volumes = [

--- a/images/awscli/BUILD
+++ b/images/awscli/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID")
 
 download_pkgs(
     name = "apt_get_download",

--- a/images/awscli/BUILD
+++ b/images/awscli/BUILD
@@ -35,6 +35,10 @@ container_image(
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/awscli",
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/awscli",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
+        "org.cardboardci.image.user": "cardboardci",
+        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.group": "cardboardci",
+        "org.cardboardci.image.gid": "180000",
     },
     user = "cardboardci",
     volumes = [

--- a/images/base/BUILD
+++ b/images/base/BUILD
@@ -46,6 +46,9 @@ container_image(
     entrypoint = "",
     env = {
         "CARDBOARDCI_WORKSPACE": "/workspace",
+        "LANG": "en_US.UTF-8",
+        "LANGUAGE": "en_US:en",
+        "LC_ALL": "en_US.UTF-8",
     },
     files = glob(["image_data/*"]),
     labels = {

--- a/images/base/BUILD
+++ b/images/base/BUILD
@@ -55,6 +55,10 @@ container_image(
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/base",
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/base",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
+        "org.cardboardci.image.user": "cardboardci",
+        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.group": "cardboardci",
+        "org.cardboardci.image.gid": "180000",
     },
     visibility = ["//visibility:public"],
     volumes = [

--- a/images/base/BUILD
+++ b/images/base/BUILD
@@ -3,7 +3,7 @@ load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "instal
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_commit")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -29,8 +29,11 @@ install_pkgs(
 container_run_and_commit(
     name = "bin_install",
     commands = [
-        "groupadd -r -g {gid} cardboardci".format(gid=CARDBOARDCI_GID),
-        "useradd --uid={uid} --gid={gid} --create-home cardboardci".format(uid=CARDBOARDCI_UID, gid=CARDBOARDCI_GID),
+        "groupadd -r -g {gid} cardboardci".format(gid = CARDBOARDCI_GID),
+        "useradd --uid={uid} --gid={gid} --create-home cardboardci".format(
+            uid = CARDBOARDCI_UID,
+            gid = CARDBOARDCI_GID,
+        ),
         "locale-gen en_US.UTF-8",
     ],
     image = ":apt_get_installed.tar",

--- a/images/base/BUILD
+++ b/images/base/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "instal
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_commit")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -28,8 +29,8 @@ install_pkgs(
 container_run_and_commit(
     name = "bin_install",
     commands = [
-        "groupadd -r -g 180000 cardboardci",
-        "useradd --uid=180000 --gid=180000 --create-home cardboardci",
+        "groupadd -r -g {gid} cardboardci".format(gid=CARDBOARDCI_GID),
+        "useradd --uid={uid} --gid={gid} --create-home cardboardci".format(uid=CARDBOARDCI_UID, gid=CARDBOARDCI_GID),
         "locale-gen en_US.UTF-8",
     ],
     image = ":apt_get_installed.tar",
@@ -56,9 +57,9 @@ container_image(
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/base",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
         "org.cardboardci.image.user": "cardboardci",
-        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.uid": CARDBOARDCI_UID,
         "org.cardboardci.image.group": "cardboardci",
-        "org.cardboardci.image.gid": "180000",
+        "org.cardboardci.image.gid": CARDBOARDCI_GID,
     },
     visibility = ["//visibility:public"],
     volumes = [

--- a/images/bats/BUILD
+++ b/images/bats/BUILD
@@ -49,6 +49,10 @@ container_image(
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/bats",
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/bats",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
+        "org.cardboardci.image.user": "cardboardci",
+        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.group": "cardboardci",
+        "org.cardboardci.image.gid": "180000",
     },
     user = "cardboardci",
     volumes = [

--- a/images/bats/BUILD
+++ b/images/bats/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "npm_download_and_install", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID", "npm_download_and_install")
 
 download_pkgs(
     name = "apt_get_download",

--- a/images/bats/BUILD
+++ b/images/bats/BUILD
@@ -47,6 +47,8 @@ container_image(
         "org.opencontainers.image.summary": "Bash Automated Testing System",
         "org.opencontainers.image.description": "Bats is most useful when testing software written in Bash, but you can use it to test any UNIX program",
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/bats",
+        "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/bats",
+        "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
     },
     user = "cardboardci",
     volumes = [

--- a/images/bats/BUILD
+++ b/images/bats/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "npm_download_and_install")
+load("@cardboardci//rules:wrappers.bzl", "npm_download_and_install", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -50,9 +50,9 @@ container_image(
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/bats",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
         "org.cardboardci.image.user": "cardboardci",
-        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.uid": CARDBOARDCI_UID,
         "org.cardboardci.image.group": "cardboardci",
-        "org.cardboardci.image.gid": "180000",
+        "org.cardboardci.image.gid": CARDBOARDCI_GID,
     },
     user = "cardboardci",
     volumes = [

--- a/images/cppcheck/BUILD
+++ b/images/cppcheck/BUILD
@@ -41,6 +41,8 @@ container_image(
         "org.opencontainers.image.summary": "C++ linter",
         "org.opencontainers.image.description": "Static analysis of C/C++ code",
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/cppcheck",
+        "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/cppcheck",
+        "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
     },
     user = "cardboardci",
     volumes = [

--- a/images/cppcheck/BUILD
+++ b/images/cppcheck/BUILD
@@ -43,6 +43,10 @@ container_image(
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/cppcheck",
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/cppcheck",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
+        "org.cardboardci.image.user": "cardboardci",
+        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.group": "cardboardci",
+        "org.cardboardci.image.gid": "180000",
     },
     user = "cardboardci",
     volumes = [

--- a/images/cppcheck/BUILD
+++ b/images/cppcheck/BUILD
@@ -2,6 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -44,9 +45,9 @@ container_image(
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/cppcheck",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
         "org.cardboardci.image.user": "cardboardci",
-        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.uid": CARDBOARDCI_UID,
         "org.cardboardci.image.group": "cardboardci",
-        "org.cardboardci.image.gid": "180000",
+        "org.cardboardci.image.gid": CARDBOARDCI_GID,
     },
     user = "cardboardci",
     volumes = [

--- a/images/cppcheck/BUILD
+++ b/images/cppcheck/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID")
 
 download_pkgs(
     name = "apt_get_download",

--- a/images/dbxcli/BUILD
+++ b/images/dbxcli/BUILD
@@ -43,6 +43,8 @@ container_image(
         "org.opencontainers.image.summary": "Dropbox CLI",
         "org.opencontainers.image.description": "A command line client for Dropbox built using the Go SDK.",
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/dbxcli",
+        "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/dbxcli",
+        "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
     },
     user = "cardboardci",
     volumes = [

--- a/images/dbxcli/BUILD
+++ b/images/dbxcli/BUILD
@@ -45,6 +45,10 @@ container_image(
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/dbxcli",
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/dbxcli",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
+        "org.cardboardci.image.user": "cardboardci",
+        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.group": "cardboardci",
+        "org.cardboardci.image.gid": "180000",
     },
     user = "cardboardci",
     volumes = [

--- a/images/dbxcli/BUILD
+++ b/images/dbxcli/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "instal
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "binary_download_and_install")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -46,9 +47,9 @@ container_image(
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/dbxcli",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
         "org.cardboardci.image.user": "cardboardci",
-        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.uid": CARDBOARDCI_UID,
         "org.cardboardci.image.group": "cardboardci",
-        "org.cardboardci.image.gid": "180000",
+        "org.cardboardci.image.gid": CARDBOARDCI_GID,
     },
     user = "cardboardci",
     volumes = [

--- a/images/dbxcli/BUILD
+++ b/images/dbxcli/BUILD
@@ -2,8 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "binary_download_and_install")
-load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID", "binary_download_and_install")
 
 download_pkgs(
     name = "apt_get_download",

--- a/images/ecr/BUILD
+++ b/images/ecr/BUILD
@@ -38,6 +38,8 @@ container_image(
         "org.opencontainers.image.summary": "AWS ECR",
         "org.opencontainers.image.description": "A unified tool to deploy Docker images to Amazon Elastic Container Registry (ECR)",
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/ecr",
+        "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/ecr",
+        "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
     },
     user = "cardboardci",
     volumes = [

--- a/images/ecr/BUILD
+++ b/images/ecr/BUILD
@@ -40,6 +40,10 @@ container_image(
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/ecr",
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/ecr",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
+        "org.cardboardci.image.user": "cardboardci",
+        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.group": "cardboardci",
+        "org.cardboardci.image.gid": "180000",
     },
     user = "cardboardci",
     volumes = [

--- a/images/ecr/BUILD
+++ b/images/ecr/BUILD
@@ -2,6 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -41,9 +42,9 @@ container_image(
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/ecr",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
         "org.cardboardci.image.user": "cardboardci",
-        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.uid": CARDBOARDCI_UID,
         "org.cardboardci.image.group": "cardboardci",
-        "org.cardboardci.image.gid": "180000",
+        "org.cardboardci.image.gid": CARDBOARDCI_GID,
     },
     user = "cardboardci",
     volumes = [

--- a/images/ecr/BUILD
+++ b/images/ecr/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID")
 
 download_pkgs(
     name = "apt_get_download",

--- a/images/github/BUILD
+++ b/images/github/BUILD
@@ -2,8 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "deb_download_and_install")
-load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID", "deb_download_and_install")
 
 download_pkgs(
     name = "apt_get_download",

--- a/images/github/BUILD
+++ b/images/github/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "instal
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "deb_download_and_install")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -51,9 +52,9 @@ container_image(
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/github",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
         "org.cardboardci.image.user": "cardboardci",
-        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.uid": CARDBOARDCI_UID,
         "org.cardboardci.image.group": "cardboardci",
-        "org.cardboardci.image.gid": "180000",
+        "org.cardboardci.image.gid": CARDBOARDCI_GID,
     },
     user = "cardboardci",
     volumes = [

--- a/images/github/BUILD
+++ b/images/github/BUILD
@@ -50,6 +50,10 @@ container_image(
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/github",
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/github",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
+        "org.cardboardci.image.user": "cardboardci",
+        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.group": "cardboardci",
+        "org.cardboardci.image.gid": "180000",
     },
     user = "cardboardci",
     volumes = [

--- a/images/github/BUILD
+++ b/images/github/BUILD
@@ -48,6 +48,8 @@ container_image(
         "org.opencontainers.image.summary": "GitHub CLI",
         "org.opencontainers.image.description": "A command-line tool that makes git easier to use with GitHub",
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/github",
+        "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/github",
+        "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
     },
     user = "cardboardci",
     volumes = [

--- a/images/gitlab/BUILD
+++ b/images/gitlab/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "instal
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_commit")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -57,9 +58,9 @@ container_image(
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/gitlab",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
         "org.cardboardci.image.user": "cardboardci",
-        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.uid": CARDBOARDCI_UID,
         "org.cardboardci.image.group": "cardboardci",
-        "org.cardboardci.image.gid": "180000",
+        "org.cardboardci.image.gid": CARDBOARDCI_GID,
     },
     user = "cardboardci",
     volumes = [

--- a/images/gitlab/BUILD
+++ b/images/gitlab/BUILD
@@ -3,7 +3,7 @@ load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "instal
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_commit")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID")
 
 download_pkgs(
     name = "apt_get_download",

--- a/images/gitlab/BUILD
+++ b/images/gitlab/BUILD
@@ -56,6 +56,10 @@ container_image(
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/gitlab",
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/gitlab",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
+        "org.cardboardci.image.user": "cardboardci",
+        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.group": "cardboardci",
+        "org.cardboardci.image.gid": "180000",
     },
     user = "cardboardci",
     volumes = [

--- a/images/gitlab/BUILD
+++ b/images/gitlab/BUILD
@@ -54,6 +54,8 @@ container_image(
         "org.opencontainers.image.summary": "GitLab CLI",
         "org.opencontainers.image.description": "Lab wraps Git or Hub, making it simple to clone, fork, and interact with repositories on GitLab",
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/gitlab",
+        "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/gitlab",
+        "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
     },
     user = "cardboardci",
     volumes = [

--- a/images/hadolint/BUILD
+++ b/images/hadolint/BUILD
@@ -2,8 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "binary_download_and_install")
-load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID", "binary_download_and_install")
 
 download_pkgs(
     name = "apt_get_download",

--- a/images/hadolint/BUILD
+++ b/images/hadolint/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "instal
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "binary_download_and_install")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -49,9 +50,9 @@ container_image(
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/hadolint",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
         "org.cardboardci.image.user": "cardboardci",
-        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.uid": CARDBOARDCI_UID,
         "org.cardboardci.image.group": "cardboardci",
-        "org.cardboardci.image.gid": "180000",
+        "org.cardboardci.image.gid": CARDBOARDCI_GID,
     },
     user = "cardboardci",
     volumes = [

--- a/images/hadolint/BUILD
+++ b/images/hadolint/BUILD
@@ -46,6 +46,8 @@ container_image(
         "org.opencontainers.image.summary": "Dockerfile linter",
         "org.opencontainers.image.description": "Dockerfile linter, validate inline bash, written in Haskell",
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/hadolint",
+        "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/hadolint",
+        "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
     },
     user = "cardboardci",
     volumes = [

--- a/images/hadolint/BUILD
+++ b/images/hadolint/BUILD
@@ -48,6 +48,10 @@ container_image(
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/hadolint",
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/hadolint",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
+        "org.cardboardci.image.user": "cardboardci",
+        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.group": "cardboardci",
+        "org.cardboardci.image.gid": "180000",
     },
     user = "cardboardci",
     volumes = [

--- a/images/htmlhint/BUILD
+++ b/images/htmlhint/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "instal
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "npm_download_and_install")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -50,9 +51,9 @@ container_image(
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/htmlhint",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
         "org.cardboardci.image.user": "cardboardci",
-        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.uid": CARDBOARDCI_UID,
         "org.cardboardci.image.group": "cardboardci",
-        "org.cardboardci.image.gid": "180000",
+        "org.cardboardci.image.gid": CARDBOARDCI_GID,
     },
     user = "cardboardci",
     volumes = [

--- a/images/htmlhint/BUILD
+++ b/images/htmlhint/BUILD
@@ -49,6 +49,10 @@ container_image(
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/htmlhint",
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/htmlhint",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
+        "org.cardboardci.image.user": "cardboardci",
+        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.group": "cardboardci",
+        "org.cardboardci.image.gid": "180000",
     },
     user = "cardboardci",
     volumes = [

--- a/images/htmlhint/BUILD
+++ b/images/htmlhint/BUILD
@@ -47,6 +47,8 @@ container_image(
         "org.opencontainers.image.summary": "HTML linter",
         "org.opencontainers.image.description": "The static code analysis tool you need for your HTML",
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/htmlhint",
+        "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/htmlhint",
+        "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
     },
     user = "cardboardci",
     volumes = [

--- a/images/htmlhint/BUILD
+++ b/images/htmlhint/BUILD
@@ -2,8 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "npm_download_and_install")
-load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID", "npm_download_and_install")
 
 download_pkgs(
     name = "apt_get_download",

--- a/images/hugo/BUILD
+++ b/images/hugo/BUILD
@@ -48,6 +48,8 @@ container_image(
         "org.opencontainers.image.summary": "Hugo static site generator",
         "org.opencontainers.image.description": "Hugo is an open-source static site generator",
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/hugo",
+        "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/hugo",
+        "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
     },
     user = "cardboardci",
     volumes = [

--- a/images/hugo/BUILD
+++ b/images/hugo/BUILD
@@ -2,8 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "deb_download_and_install")
-load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID", "deb_download_and_install")
 
 download_pkgs(
     name = "apt_get_download",

--- a/images/hugo/BUILD
+++ b/images/hugo/BUILD
@@ -50,6 +50,10 @@ container_image(
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/hugo",
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/hugo",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
+        "org.cardboardci.image.user": "cardboardci",
+        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.group": "cardboardci",
+        "org.cardboardci.image.gid": "180000",
     },
     user = "cardboardci",
     volumes = [

--- a/images/hugo/BUILD
+++ b/images/hugo/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "instal
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "deb_download_and_install")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -51,9 +52,9 @@ container_image(
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/hugo",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
         "org.cardboardci.image.user": "cardboardci",
-        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.uid": CARDBOARDCI_UID,
         "org.cardboardci.image.group": "cardboardci",
-        "org.cardboardci.image.gid": "180000",
+        "org.cardboardci.image.gid": CARDBOARDCI_GID,
     },
     user = "cardboardci",
     volumes = [

--- a/images/luacheck/BUILD
+++ b/images/luacheck/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "instal
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "luacheck_download_and_install")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -51,9 +52,9 @@ container_image(
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/luacheck",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
         "org.cardboardci.image.user": "cardboardci",
-        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.uid": CARDBOARDCI_UID,
         "org.cardboardci.image.group": "cardboardci",
-        "org.cardboardci.image.gid": "180000",
+        "org.cardboardci.image.gid": CARDBOARDCI_GID,
     },
     user = "cardboardci",
     volumes = [

--- a/images/luacheck/BUILD
+++ b/images/luacheck/BUILD
@@ -50,6 +50,10 @@ container_image(
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/luacheck",
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/luacheck",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
+        "org.cardboardci.image.user": "cardboardci",
+        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.group": "cardboardci",
+        "org.cardboardci.image.gid": "180000",
     },
     user = "cardboardci",
     volumes = [

--- a/images/luacheck/BUILD
+++ b/images/luacheck/BUILD
@@ -48,6 +48,8 @@ container_image(
         "org.opencontainers.image.summary": "Lua linter",
         "org.opencontainers.image.description": "Luacheck is a static analyzer and a linter for Lua",
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/luacheck",
+        "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/luacheck",
+        "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
     },
     user = "cardboardci",
     volumes = [

--- a/images/luacheck/BUILD
+++ b/images/luacheck/BUILD
@@ -2,8 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "luacheck_download_and_install")
-load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID", "luacheck_download_and_install")
 
 download_pkgs(
     name = "apt_get_download",

--- a/images/markdownlint/BUILD
+++ b/images/markdownlint/BUILD
@@ -47,6 +47,8 @@ container_image(
         "org.opencontainers.image.summary": "NodeJS linter",
         "org.opencontainers.image.description": "A Node.js style checker and lint tool for Markdown/CommonMark files",
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/markdownlint",
+        "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/markdownlint",
+        "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
     },
     user = "cardboardci",
     volumes = [

--- a/images/markdownlint/BUILD
+++ b/images/markdownlint/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "instal
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "npm_download_and_install")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -50,9 +51,9 @@ container_image(
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/markdownlint",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
         "org.cardboardci.image.user": "cardboardci",
-        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.uid": CARDBOARDCI_UID,
         "org.cardboardci.image.group": "cardboardci",
-        "org.cardboardci.image.gid": "180000",
+        "org.cardboardci.image.gid": CARDBOARDCI_GID,
     },
     user = "cardboardci",
     volumes = [

--- a/images/markdownlint/BUILD
+++ b/images/markdownlint/BUILD
@@ -49,6 +49,10 @@ container_image(
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/markdownlint",
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/markdownlint",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
+        "org.cardboardci.image.user": "cardboardci",
+        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.group": "cardboardci",
+        "org.cardboardci.image.gid": "180000",
     },
     user = "cardboardci",
     volumes = [

--- a/images/markdownlint/BUILD
+++ b/images/markdownlint/BUILD
@@ -2,8 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "npm_download_and_install")
-load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID", "npm_download_and_install")
 
 download_pkgs(
     name = "apt_get_download",

--- a/images/netlify/BUILD
+++ b/images/netlify/BUILD
@@ -49,6 +49,10 @@ container_image(
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/netlify",
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/netlify",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
+        "org.cardboardci.image.user": "cardboardci",
+        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.group": "cardboardci",
+        "org.cardboardci.image.gid": "180000",
     },
     user = "cardboardci",
     volumes = [

--- a/images/netlify/BUILD
+++ b/images/netlify/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "instal
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "npm_download_and_install")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -50,9 +51,9 @@ container_image(
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/netlify",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
         "org.cardboardci.image.user": "cardboardci",
-        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.uid": CARDBOARDCI_UID,
         "org.cardboardci.image.group": "cardboardci",
-        "org.cardboardci.image.gid": "180000",
+        "org.cardboardci.image.gid": CARDBOARDCI_GID,
     },
     user = "cardboardci",
     volumes = [

--- a/images/netlify/BUILD
+++ b/images/netlify/BUILD
@@ -47,6 +47,8 @@ container_image(
         "org.opencontainers.image.summary": "Netlify CLI",
         "org.opencontainers.image.description": "Netlify builds, deploys and hosts your netlify services",
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/netlify",
+        "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/netlify",
+        "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
     },
     user = "cardboardci",
     volumes = [

--- a/images/netlify/BUILD
+++ b/images/netlify/BUILD
@@ -2,8 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "npm_download_and_install")
-load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID", "npm_download_and_install")
 
 download_pkgs(
     name = "apt_get_download",

--- a/images/pdf2htmlex/BUILD
+++ b/images/pdf2htmlex/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "instal
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "deb_download_and_install")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -68,9 +69,9 @@ container_image(
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/pdf2htmlex",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
         "org.cardboardci.image.user": "cardboardci",
-        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.uid": CARDBOARDCI_UID,
         "org.cardboardci.image.group": "cardboardci",
-        "org.cardboardci.image.gid": "180000",
+        "org.cardboardci.image.gid": CARDBOARDCI_GID,
     },
     user = "cardboardci",
     volumes = [

--- a/images/pdf2htmlex/BUILD
+++ b/images/pdf2htmlex/BUILD
@@ -2,8 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "deb_download_and_install")
-load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID", "deb_download_and_install")
 
 download_pkgs(
     name = "apt_get_download",

--- a/images/pdf2htmlex/BUILD
+++ b/images/pdf2htmlex/BUILD
@@ -67,6 +67,10 @@ container_image(
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/pdf2htmlex",
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/pdf2htmlex",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
+        "org.cardboardci.image.user": "cardboardci",
+        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.group": "cardboardci",
+        "org.cardboardci.image.gid": "180000",
     },
     user = "cardboardci",
     volumes = [

--- a/images/pdf2htmlex/BUILD
+++ b/images/pdf2htmlex/BUILD
@@ -65,6 +65,8 @@ container_image(
         "org.opencontainers.image.summary": "PDF 2 HTML",
         "org.opencontainers.image.description": "Convert PDF to HTML without losing text or format",
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/pdf2htmlex",
+        "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/pdf2htmlex",
+        "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
     },
     user = "cardboardci",
     volumes = [

--- a/images/pdftools/BUILD
+++ b/images/pdftools/BUILD
@@ -2,6 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -38,9 +39,9 @@ container_image(
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/pdftools",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
         "org.cardboardci.image.user": "cardboardci",
-        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.uid": CARDBOARDCI_UID,
         "org.cardboardci.image.group": "cardboardci",
-        "org.cardboardci.image.gid": "180000",
+        "org.cardboardci.image.gid": CARDBOARDCI_GID,
     },
     user = "cardboardci",
     volumes = [

--- a/images/pdftools/BUILD
+++ b/images/pdftools/BUILD
@@ -35,6 +35,8 @@ container_image(
         "org.opencontainers.image.summary": "PDF CLIs",
         "org.opencontainers.image.description": " Command line tools for manipulating pdfs",
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/pdftools",
+        "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/pdftools",
+        "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
     },
     user = "cardboardci",
     volumes = [

--- a/images/pdftools/BUILD
+++ b/images/pdftools/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID")
 
 download_pkgs(
     name = "apt_get_download",

--- a/images/pdftools/BUILD
+++ b/images/pdftools/BUILD
@@ -37,6 +37,10 @@ container_image(
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/pdftools",
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/pdftools",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
+        "org.cardboardci.image.user": "cardboardci",
+        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.group": "cardboardci",
+        "org.cardboardci.image.gid": "180000",
     },
     user = "cardboardci",
     volumes = [

--- a/images/psscriptanalyzer/BUILD
+++ b/images/psscriptanalyzer/BUILD
@@ -72,6 +72,8 @@ container_image(
         "org.opencontainers.image.summary": "Powershell linter",
         "org.opencontainers.image.description": "PSScriptAnalyzer is a static code checker for Windows PowerShell modules and scripts",
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/psscriptanalyzer",
+        "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/psscriptanalyzer",
+        "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
     },
     user = "cardboardci",
     volumes = [

--- a/images/psscriptanalyzer/BUILD
+++ b/images/psscriptanalyzer/BUILD
@@ -3,7 +3,7 @@ load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "instal
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_commit")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID")
 
 download_pkgs(
     name = "apt_get_download",

--- a/images/psscriptanalyzer/BUILD
+++ b/images/psscriptanalyzer/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "instal
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_commit")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -75,9 +76,9 @@ container_image(
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/psscriptanalyzer",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
         "org.cardboardci.image.user": "cardboardci",
-        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.uid": CARDBOARDCI_UID,
         "org.cardboardci.image.group": "cardboardci",
-        "org.cardboardci.image.gid": "180000",
+        "org.cardboardci.image.gid": CARDBOARDCI_GID,
     },
     user = "cardboardci",
     volumes = [

--- a/images/psscriptanalyzer/BUILD
+++ b/images/psscriptanalyzer/BUILD
@@ -74,6 +74,10 @@ container_image(
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/psscriptanalyzer",
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/psscriptanalyzer",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
+        "org.cardboardci.image.user": "cardboardci",
+        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.group": "cardboardci",
+        "org.cardboardci.image.gid": "180000",
     },
     user = "cardboardci",
     volumes = [

--- a/images/pylint/BUILD
+++ b/images/pylint/BUILD
@@ -49,6 +49,10 @@ container_image(
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/pylint",
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/pylint",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
+        "org.cardboardci.image.user": "cardboardci",
+        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.group": "cardboardci",
+        "org.cardboardci.image.gid": "180000",
     },
     user = "cardboardci",
     volumes = [

--- a/images/pylint/BUILD
+++ b/images/pylint/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "instal
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "pip_download_and_install")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -50,9 +51,9 @@ container_image(
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/pylint",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
         "org.cardboardci.image.user": "cardboardci",
-        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.uid": CARDBOARDCI_UID,
         "org.cardboardci.image.group": "cardboardci",
-        "org.cardboardci.image.gid": "180000",
+        "org.cardboardci.image.gid": CARDBOARDCI_GID,
     },
     user = "cardboardci",
     volumes = [

--- a/images/pylint/BUILD
+++ b/images/pylint/BUILD
@@ -2,8 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "pip_download_and_install")
-load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID", "pip_download_and_install")
 
 download_pkgs(
     name = "apt_get_download",

--- a/images/pylint/BUILD
+++ b/images/pylint/BUILD
@@ -47,6 +47,8 @@ container_image(
         "org.opencontainers.image.summary": "Python linter",
         "org.opencontainers.image.description": "Pylint is a Python static code analysis tool which looks for programming errors",
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/pylint",
+        "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/pylint",
+        "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
     },
     user = "cardboardci",
     volumes = [

--- a/images/rsvg/BUILD
+++ b/images/rsvg/BUILD
@@ -37,6 +37,10 @@ container_image(
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/rsvg",
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/rsvg",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
+        "org.cardboardci.image.user": "cardboardci",
+        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.group": "cardboardci",
+        "org.cardboardci.image.gid": "180000",
     },
     user = "cardboardci",
     volumes = [

--- a/images/rsvg/BUILD
+++ b/images/rsvg/BUILD
@@ -2,6 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -38,9 +39,9 @@ container_image(
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/rsvg",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
         "org.cardboardci.image.user": "cardboardci",
-        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.uid": CARDBOARDCI_UID,
         "org.cardboardci.image.group": "cardboardci",
-        "org.cardboardci.image.gid": "180000",
+        "org.cardboardci.image.gid": CARDBOARDCI_GID,
     },
     user = "cardboardci",
     volumes = [

--- a/images/rsvg/BUILD
+++ b/images/rsvg/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID")
 
 download_pkgs(
     name = "apt_get_download",

--- a/images/rsvg/BUILD
+++ b/images/rsvg/BUILD
@@ -35,6 +35,8 @@ container_image(
         "org.opencontainers.image.summary": "Rasterize SVGs",
         "org.opencontainers.image.description": "Turn SVG files into raster images",
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/rsvg",
+        "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/rsvg",
+        "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
     },
     user = "cardboardci",
     volumes = [

--- a/images/rubocop/BUILD
+++ b/images/rubocop/BUILD
@@ -2,8 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "gem_download_and_install")
-load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID", "gem_download_and_install")
 
 download_pkgs(
     name = "apt_get_download",

--- a/images/rubocop/BUILD
+++ b/images/rubocop/BUILD
@@ -49,6 +49,10 @@ container_image(
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/rubocop",
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/rubocop",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
+        "org.cardboardci.image.user": "cardboardci",
+        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.group": "cardboardci",
+        "org.cardboardci.image.gid": "180000",
     },
     user = "cardboardci",
     volumes = [

--- a/images/rubocop/BUILD
+++ b/images/rubocop/BUILD
@@ -47,6 +47,8 @@ container_image(
         "org.opencontainers.image.summary": "Ruby static code analyzer",
         "org.opencontainers.image.description": "A Ruby static code analyzer and formatter, based on the community Ruby style guide",
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/rubocop",
+        "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/rubocop",
+        "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
     },
     user = "cardboardci",
     volumes = [

--- a/images/rubocop/BUILD
+++ b/images/rubocop/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "instal
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "gem_download_and_install")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -50,9 +51,9 @@ container_image(
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/rubocop",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
         "org.cardboardci.image.user": "cardboardci",
-        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.uid": CARDBOARDCI_UID,
         "org.cardboardci.image.group": "cardboardci",
-        "org.cardboardci.image.gid": "180000",
+        "org.cardboardci.image.gid": CARDBOARDCI_GID,
     },
     user = "cardboardci",
     volumes = [

--- a/images/shellcheck/BUILD
+++ b/images/shellcheck/BUILD
@@ -2,6 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -38,9 +39,9 @@ container_image(
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/shellcheck",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
         "org.cardboardci.image.user": "cardboardci",
-        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.uid": CARDBOARDCI_UID,
         "org.cardboardci.image.group": "cardboardci",
-        "org.cardboardci.image.gid": "180000",
+        "org.cardboardci.image.gid": CARDBOARDCI_GID,
     },
     user = "cardboardci",
     volumes = [

--- a/images/shellcheck/BUILD
+++ b/images/shellcheck/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID")
 
 download_pkgs(
     name = "apt_get_download",

--- a/images/shellcheck/BUILD
+++ b/images/shellcheck/BUILD
@@ -37,6 +37,10 @@ container_image(
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/shellcheck",
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/shellcheck",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
+        "org.cardboardci.image.user": "cardboardci",
+        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.group": "cardboardci",
+        "org.cardboardci.image.gid": "180000",
     },
     user = "cardboardci",
     volumes = [

--- a/images/shellcheck/BUILD
+++ b/images/shellcheck/BUILD
@@ -35,6 +35,8 @@ container_image(
         "org.opencontainers.image.summary": "Shell script static anaylsis",
         "org.opencontainers.image.description": "ShellCheck is a static anaylsis tool that automatically finds bugs in your shell scripts",
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/shellcheck",
+        "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/shellcheck",
+        "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
     },
     user = "cardboardci",
     volumes = [

--- a/images/stylelint/BUILD
+++ b/images/stylelint/BUILD
@@ -50,6 +50,10 @@ container_image(
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/stylelint",
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/stylelint",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
+        "org.cardboardci.image.user": "cardboardci",
+        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.group": "cardboardci",
+        "org.cardboardci.image.gid": "180000",
     },
     user = "cardboardci",
     volumes = [

--- a/images/stylelint/BUILD
+++ b/images/stylelint/BUILD
@@ -48,6 +48,8 @@ container_image(
         "org.opencontainers.image.summary": "Style linter",
         "org.opencontainers.image.description": "A mighty, modern style linter",
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/stylelint",
+        "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/stylelint",
+        "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
     },
     user = "cardboardci",
     volumes = [

--- a/images/stylelint/BUILD
+++ b/images/stylelint/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "instal
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "npm_download_and_install")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -51,9 +52,9 @@ container_image(
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/stylelint",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
         "org.cardboardci.image.user": "cardboardci",
-        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.uid": CARDBOARDCI_UID,
         "org.cardboardci.image.group": "cardboardci",
-        "org.cardboardci.image.gid": "180000",
+        "org.cardboardci.image.gid": CARDBOARDCI_GID,
     },
     user = "cardboardci",
     volumes = [

--- a/images/stylelint/BUILD
+++ b/images/stylelint/BUILD
@@ -2,8 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "npm_download_and_install")
-load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID", "npm_download_and_install")
 
 download_pkgs(
     name = "apt_get_download",

--- a/images/surge/BUILD
+++ b/images/surge/BUILD
@@ -49,6 +49,10 @@ container_image(
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/surge",
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/surge",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
+        "org.cardboardci.image.user": "cardboardci",
+        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.group": "cardboardci",
+        "org.cardboardci.image.gid": "180000",
     },
     user = "cardboardci",
     volumes = [

--- a/images/surge/BUILD
+++ b/images/surge/BUILD
@@ -47,6 +47,8 @@ container_image(
         "org.opencontainers.image.summary": "Static web publishing",
         "org.opencontainers.image.description": "Surge is static web publishing for Front-End Developers, right from the CLI",
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/surge",
+        "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/surge",
+        "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
     },
     user = "cardboardci",
     volumes = [

--- a/images/surge/BUILD
+++ b/images/surge/BUILD
@@ -2,8 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "npm_download_and_install")
-load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID", "npm_download_and_install")
 
 download_pkgs(
     name = "apt_get_download",

--- a/images/surge/BUILD
+++ b/images/surge/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "instal
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "npm_download_and_install")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -50,9 +51,9 @@ container_image(
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/surge",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
         "org.cardboardci.image.user": "cardboardci",
-        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.uid": CARDBOARDCI_UID,
         "org.cardboardci.image.group": "cardboardci",
-        "org.cardboardci.image.gid": "180000",
+        "org.cardboardci.image.gid": CARDBOARDCI_GID,
     },
     user = "cardboardci",
     volumes = [

--- a/images/svgtools/BUILD
+++ b/images/svgtools/BUILD
@@ -2,6 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -41,9 +42,9 @@ container_image(
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/svgtools",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
         "org.cardboardci.image.user": "cardboardci",
-        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.uid": CARDBOARDCI_UID,
         "org.cardboardci.image.group": "cardboardci",
-        "org.cardboardci.image.gid": "180000",
+        "org.cardboardci.image.gid": CARDBOARDCI_GID,
     },
     user = "cardboardci",
     volumes = [

--- a/images/svgtools/BUILD
+++ b/images/svgtools/BUILD
@@ -38,6 +38,8 @@ container_image(
         "org.opencontainers.image.summary": "Rasterize SVGs",
         "org.opencontainers.image.description": "Tools for working with Scalable Vector Graphics (SVG) files",
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/svgtools",
+        "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/svgtools",
+        "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
     },
     user = "cardboardci",
     volumes = [

--- a/images/svgtools/BUILD
+++ b/images/svgtools/BUILD
@@ -40,6 +40,10 @@ container_image(
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/svgtools",
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/svgtools",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
+        "org.cardboardci.image.user": "cardboardci",
+        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.group": "cardboardci",
+        "org.cardboardci.image.gid": "180000",
     },
     user = "cardboardci",
     volumes = [

--- a/images/svgtools/BUILD
+++ b/images/svgtools/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID")
 
 download_pkgs(
     name = "apt_get_download",

--- a/images/tflint/BUILD
+++ b/images/tflint/BUILD
@@ -2,8 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "zip_download_and_install")
-load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID", "zip_download_and_install")
 
 download_pkgs(
     name = "apt_get_download",

--- a/images/tflint/BUILD
+++ b/images/tflint/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "instal
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "zip_download_and_install")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -49,9 +50,9 @@ container_image(
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/tflint",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
         "org.cardboardci.image.user": "cardboardci",
-        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.uid": CARDBOARDCI_UID,
         "org.cardboardci.image.group": "cardboardci",
-        "org.cardboardci.image.gid": "180000",
+        "org.cardboardci.image.gid": CARDBOARDCI_GID,
     },
     user = "cardboardci",
     volumes = [

--- a/images/tflint/BUILD
+++ b/images/tflint/BUILD
@@ -48,6 +48,10 @@ container_image(
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/tflint",
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/tflint",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
+        "org.cardboardci.image.user": "cardboardci",
+        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.group": "cardboardci",
+        "org.cardboardci.image.gid": "180000",
     },
     user = "cardboardci",
     volumes = [

--- a/images/tflint/BUILD
+++ b/images/tflint/BUILD
@@ -46,6 +46,8 @@ container_image(
         "org.opencontainers.image.summary": "Terraform linter",
         "org.opencontainers.image.description": "TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan",
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/tflint",
+        "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/tflint",
+        "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
     },
     user = "cardboardci",
     volumes = [

--- a/images/wkhtmltopdf/BUILD
+++ b/images/wkhtmltopdf/BUILD
@@ -61,6 +61,10 @@ container_image(
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/wkhtmltopdf",
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/wkhtmltopdf",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
+        "org.cardboardci.image.user": "cardboardci",
+        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.group": "cardboardci",
+        "org.cardboardci.image.gid": "180000",
     },
     user = "cardboardci",
     volumes = [

--- a/images/wkhtmltopdf/BUILD
+++ b/images/wkhtmltopdf/BUILD
@@ -2,8 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:wrappers.bzl", "deb_download_and_install")
-load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID", "deb_download_and_install")
 
 download_pkgs(
     name = "apt_get_download",

--- a/images/wkhtmltopdf/BUILD
+++ b/images/wkhtmltopdf/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "instal
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "deb_download_and_install")
+load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_UID", "CARDBOARDCI_GID")
 
 download_pkgs(
     name = "apt_get_download",
@@ -62,9 +63,9 @@ container_image(
         "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/wkhtmltopdf",
         "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
         "org.cardboardci.image.user": "cardboardci",
-        "org.cardboardci.image.uid": "180000",
+        "org.cardboardci.image.uid": CARDBOARDCI_UID,
         "org.cardboardci.image.group": "cardboardci",
-        "org.cardboardci.image.gid": "180000",
+        "org.cardboardci.image.gid": CARDBOARDCI_GID,
     },
     user = "cardboardci",
     volumes = [

--- a/images/wkhtmltopdf/BUILD
+++ b/images/wkhtmltopdf/BUILD
@@ -59,6 +59,8 @@ container_image(
         "org.opencontainers.image.summary": "Render HTML into PDFs",
         "org.opencontainers.image.description": "wkhtmltopdf is a command line tools to render HTML into PDF",
         "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/wkhtmltopdf",
+        "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/wkhtmltopdf",
+        "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
     },
     user = "cardboardci",
     volumes = [

--- a/rules/wrappers.bzl
+++ b/rules/wrappers.bzl
@@ -4,8 +4,8 @@ A collection of wrappers for installing from package managers.
 
 load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_commit")
 
-CARDBOARDCI_UID="18000"
-CARDBOARDCI_GID="18000"
+CARDBOARDCI_UID = "18000"
+CARDBOARDCI_GID = "18000"
 
 def luacheck_download_and_install(name, image, packages):
     commands = ["luarocks install %s" % p for p in packages]

--- a/rules/wrappers.bzl
+++ b/rules/wrappers.bzl
@@ -4,8 +4,8 @@ A collection of wrappers for installing from package managers.
 
 load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_commit")
 
-USER_UID="18000"
-GROUP_UID="18000"
+CARDBOARDCI_UID="18000"
+CARDBOARDCI_GID="18000"
 
 def luacheck_download_and_install(name, image, packages):
     commands = ["luarocks install %s" % p for p in packages]

--- a/rules/wrappers.bzl
+++ b/rules/wrappers.bzl
@@ -4,6 +4,9 @@ A collection of wrappers for installing from package managers.
 
 load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_commit")
 
+USER_UID="18000"
+GROUP_UID="18000"
+
 def luacheck_download_and_install(name, image, packages):
     commands = ["luarocks install %s" % p for p in packages]
     container_run_and_commit(

--- a/rules/wrappers.bzl
+++ b/rules/wrappers.bzl
@@ -4,8 +4,8 @@ A collection of wrappers for installing from package managers.
 
 load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_commit")
 
-CARDBOARDCI_UID = "18000"
-CARDBOARDCI_GID = "18000"
+CARDBOARDCI_UID = "180000"
+CARDBOARDCI_GID = "180000"
 
 def luacheck_download_and_install(name, image, packages):
     commands = ["luarocks install %s" % p for p in packages]

--- a/tests/metadata.yaml
+++ b/tests/metadata.yaml
@@ -24,12 +24,12 @@ metadataTest:
         - key: "org.opencontainers.image.source"
           value: "https://github.com/cardboardci/dockerfiles/.*"
           isRegex: true
-        # - key: "org.opencontainers.image.url"
-        #   value: "https://github.com/cardboardci/dockerfiles/.*"
-        #   isRegex: true
-        # - key: "org.opencontainers.image.documentation"
-        #   value: "https://cardboardci.jrbeverly.me"
-        #   isRegex: true
+        - key: "org.opencontainers.image.url"
+          value: "https://github.com/cardboardci/dockerfiles/.*"
+          isRegex: true
+        - key: "org.opencontainers.image.documentation"
+          value: "https://cardboardci.jrbeverly.me"
+          isRegex: true
         - key: "org.opencontainers.image.title"
           value: ".*"
           isRegex: true

--- a/tests/metadata.yaml
+++ b/tests/metadata.yaml
@@ -42,6 +42,14 @@ metadataTest:
         - key: "org.opencontainers.image.description"
           value: ".*"
           isRegex: true
+        - key: "org.cardboardci.image.user"
+          value: "cardboardci"
+        - key: "org.cardboardci.image.uid"
+          value: "180000"
+        - key: "org.cardboardci.image.group"
+          value: "cardboardci"
+        - key: "org.cardboardci.image.gid"
+          value: "180000"
     exposedPorts: []
     volumes: ["/workspace"]
     cmd: ["/bin/bash"]


### PR DESCRIPTION
Add label mappings for user & groups, and include missing URL and documentation labels.

This adds in missing labels for image URL and documentation labels. The user uid/gid have been added to the image itself, to ensure that the intended user of the image can be retrieved programmatically.