### PR TITLE
fix(upgrader): Escape inputs to github command

### DIFF
--- a/.github/actions/git-commit/action.yml
+++ b/.github/actions/git-commit/action.yml
@@ -22,5 +22,5 @@ runs:
         git commit -m "GitHub Actions commit by ${GITHUB_WORKFLOW}"
         if [ $? -eq 0 ]; then
           git push -u github --force HEAD
-          gh pr create --title "${{ inputs.title }}" --body "${{ inputs.body }}" --assignee "${{ inputs.username }}" ${{ inputs.options }}
+          gh pr create --title '${{ inputs.title }}' --body '${{ inputs.body }}' --assignee '${{ inputs.username }}' ${{ inputs.options }}
         fi

--- a/.github/workflows/upgrader.base.yml
+++ b/.github/workflows/upgrader.base.yml
@@ -56,5 +56,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CARDBOARDCI_PAT_TOKEN }}
         with:
           options: "--label dependencies"
-          body: "Automated upgrading of the base image ubuntu to tag \`${{ steps.dockerhub.outputs.image-tag }}\`.\n\nReplaces digest at digest \`${{ steps.source.outputs.image-digest }}\` to the digest of tag \`${{ steps.dockerhub.outputs.image-tag }}\` (\`${{ steps.dockerhub.outputs.image-digest }}\`)"
+          body: "Automated upgrading of the base image ubuntu to tag `${{ steps.dockerhub.outputs.image-tag }}`.\n\nReplaces digest at digest `${{ steps.source.outputs.image-digest }}` to the digest of tag `${{ steps.dockerhub.outputs.image-tag }}` (`${{ steps.dockerhub.outputs.image-digest }}`)"
           title: "Bump base ubuntu image to ${{ steps.dockerhub.outputs.image-tag }} tag"


### PR DESCRIPTION
Prevent the inputs to the githubcli from being executed when receiving '`' characters.