### PR TITLE
Bump base image to focal-20210119 tag

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,7 +28,7 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 
 container_pull(
     name = "ubuntu",
-    digest = "sha256:3093096ee188f8ff4531949b8f6115af4747ec1c58858c091c8cb4579c39cc4e",
+    digest = "sha256:703218c0465075f4425e58fac086e09e1de5c340b12976ab9eb8ad26615c3715",
     registry = "index.docker.io",
     repository = "library/ubuntu",
 )


### PR DESCRIPTION
Bumps the base image to .

Replaces the old ubuntu image digest with the latest digest for tag .
 - source-digest: 
 - tag-digest: 