### PR TITLE
Bump base image to focal-20210119 tag

### DIFF
--- a/.github/actions/git-commit/action.yml
+++ b/.github/actions/git-commit/action.yml
@@ -21,6 +21,6 @@ runs:
       run: |
         git commit -m "GitHub Actions commit by ${GITHUB_WORKFLOW}"
         if [ $? -eq 0 ]; then
-          git push -u github --force HEAD
-          gh pr create --title '${{ inputs.title }}' --body '${{ inputs.body }}' --assignee '${{ inputs.username }}' ${{ inputs.options }}
+          git push -u github HEAD
+          gh pr create --title "${{ inputs.title }}" --body "${{ inputs.body }}" --assignee "${{ inputs.username }}" ${{ inputs.options }}
         fi

--- a/.github/actions/git-commit/action.yml
+++ b/.github/actions/git-commit/action.yml
@@ -4,6 +4,9 @@ branding:
   icon: "git-commit"
   color: "green"
 inputs:
+  username:
+    description: 'Username of the GitHub actor'
+    required: true
   title:
     description: "Title of the pull request"
     required: true
@@ -22,5 +25,5 @@ runs:
         git commit -m "GitHub Actions commit by ${GITHUB_WORKFLOW}"
         if [ $? -eq 0 ]; then
           git push -u github HEAD
-          gh pr create --title "${{ inputs.title }}" --body "${{ inputs.body }}" --assignee "${{ inputs.username }}" ${{ inputs.options }}
+          gh pr create --title '${{ inputs.title }}' --body '${{ inputs.body }}' --assignee '${{ inputs.username }}' ${{ inputs.options }}
         fi

--- a/.github/actions/git-config/action.yml
+++ b/.github/actions/git-config/action.yml
@@ -11,7 +11,10 @@ inputs:
     description: 'Email of the GitHub actor'
     required: true
   branch:
-    description: 'Temporary'
+    description: 'The name of the branch to checkout'
+    required: true
+  token:
+    description: 'GitHub Token used in remote setup'
     required: true
 runs:
   using: "composite"
@@ -21,5 +24,5 @@ runs:
       run: |
         git config --global user.name "${{ inputs.username }}"
         git config --global user.email "${{ inputs.email }}"
-        git remote add github "https://${{ inputs.username }}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        git remote add github "https://${{ inputs.username }}:${{ inputs.token }}@github.com/${GITHUB_REPOSITORY}.git"
         git checkout "${{ inputs.branch }}" || git checkout -b "${{ inputs.branch }}"

--- a/.github/workflows/upgrader.base.yml
+++ b/.github/workflows/upgrader.base.yml
@@ -41,7 +41,7 @@ jobs:
           branch: 'base-image-to-${{ steps.dockerhub.outputs.image-tag }}'
           token: ${{ secrets.CARDBOARDCI_PAT_TOKEN }}
       - name: Buildozer to edit digest
-        if: ${{ steps.dockerhub.outputs.image-digest != steps.source.outputs.image-digest }}
+        # if: ${{ steps.dockerhub.outputs.image-digest != steps.source.outputs.image-digest }}
         run: |
           set -x
           cat WORKSPACE | ./buildozer 'set digest "${{ steps.dockerhub.outputs.image-digest }}"' "-:ubuntu" | tee WORKSPACE.tmp
@@ -50,7 +50,7 @@ jobs:
           git add -f WORKSPACE
       - name: Commit all of the dependencies
         uses: ./.github/actions/git-commit
-        if: ${{ steps.dockerhub.outputs.image-digest != steps.source.outputs.image-digest && github.ref == 'refs/heads/master' }}
+        # if: ${{ steps.dockerhub.outputs.image-digest != steps.source.outputs.image-digest && github.ref == 'refs/heads/master' }}
         env:
           GITHUB_TOKEN: ${{ secrets.CARDBOARDCI_PAT_TOKEN }}
         with:

--- a/.github/workflows/upgrader.base.yml
+++ b/.github/workflows/upgrader.base.yml
@@ -35,12 +35,11 @@ jobs:
       - name: Configure git
         if: ${{ steps.dockerhub.outputs.image-digest != steps.source.outputs.image-digest }}
         uses: ./.github/actions/git-config
-        env:
-          GITHUB_TOKEN: ${{ secrets.CARDBOARDCI_PAT_TOKEN }}
         with:
           username: jrbeverly
           email: jonathan@jrbeverly.me
           branch: 'base-image-to-${{ steps.dockerhub.outputs.image-tag }}'
+          token: ${{ secrets.CARDBOARDCI_PAT_TOKEN }}
       - name: Buildozer to edit digest
         if: ${{ steps.dockerhub.outputs.image-digest != steps.source.outputs.image-digest }}
         run: |
@@ -56,5 +55,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CARDBOARDCI_PAT_TOKEN }}
         with:
           options: "--label dependencies"
-          body: "Automated upgrading of the base image ubuntu to tag `${{ steps.dockerhub.outputs.image-tag }}`.\n\nReplaces digest at digest `${{ steps.source.outputs.image-digest }}` to the digest of tag `${{ steps.dockerhub.outputs.image-tag }}` (`${{ steps.dockerhub.outputs.image-digest }}`)"
-          title: "Bump base ubuntu image to ${{ steps.dockerhub.outputs.image-tag }} tag"
+          body: "Bumps the base image to `${{ steps.dockerhub.outputs.image-tag }}`.\n\nReplaces the old ubuntu image digest with the latest digest for tag `${{ steps.dockerhub.outputs.image-tag }}`.\n - source-digest: `${{ steps.source.outputs.image-digest }}`\n - tag-digest: `${{ steps.dockerhub.outputs.image-digest }}`"
+          title: "Bump base image to ${{ steps.dockerhub.outputs.image-tag }} tag"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,7 +28,7 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 
 container_pull(
     name = "ubuntu",
-    digest = "sha256:3093096ee188f8ff4531949b8f6115af4747ec1c58858c091c8cb4579c39cc4e",
+    digest = "sha256:703218c0465075f4425e58fac086e09e1de5c340b12976ab9eb8ad26615c3715",
     registry = "index.docker.io",
     repository = "library/ubuntu",
 )


### PR DESCRIPTION
Bumps the base image to `focal-20210119`.

Replaces the old ubuntu image digest with the latest digest for tag `focal-20210119`.
 - source-digest: `sha256:3093096ee188f8ff4531949b8f6115af4747ec1c58858c091c8cb4579c39cc4e`
 - tag-digest: `sha256:703218c0465075f4425e58fac086e09e1de5c340b12976ab9eb8ad26615c3715`