### PR TITLE
Bump base image to focal-20210119 tag

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,10 +25,9 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 
 pip_deps()
 
-
 container_pull(
     name = "ubuntu",
-    digest = "sha256:3093096ee188f8ff4531949b8f6115af4747ec1c58858c091c8cb4579c39cc4e",
+    digest = "sha256:703218c0465075f4425e58fac086e09e1de5c340b12976ab9eb8ad26615c3715",
     registry = "index.docker.io",
     repository = "library/ubuntu",
 )


### PR DESCRIPTION
Bumps the base image to `focal-20210119`.

Replaces the old ubuntu image digest with the latest digest for tag `focal-20210119`.
 - source-digest: `sha256:3093096ee188f8ff4531949b8f6115af4747ec1c58858c091c8cb4579c39cc4e`
 - tag-digest: `sha256:703218c0465075f4425e58fac086e09e1de5c340b12976ab9eb8ad26615c3715`