### PR TITLE
fix(upgrader): Wrong digest pulled from docker pull

### DIFF
--- a/.github/actions/docker-image-digest/action.yml
+++ b/.github/actions/docker-image-digest/action.yml
@@ -7,6 +7,9 @@ inputs:
   image:
     description: 'The namespace of the image'
     required: true
+  architecture:
+    description: 'The architecture of the image'
+    required: true
   tag:
     description: 'The tag of the image'
     required: true
@@ -14,19 +17,33 @@ outputs:
   image-digest:
     description: "The image digest"
     value: ${{ steps.action.outputs.image-digest }}
-  image-tag:
-    description: "The image tag"
-    value: ${{ steps.action.outputs.image-tag }}
 runs:
   using: "composite"
   steps:
     - id: action
       shell: bash
       run: |
-          request_url="https://${{ inputs.url }}/v1/repositories/${{ inputs.image }}/tags"
-          echo "Request: ${request_url}"
-          latest=$(wget -q "${request_url}" -O - | tr -d '[]" ' | tr '}' '\n' | awk -F: '{print $3}' | grep '${{ inputs.tag }}' | sort -rn | head -n1)
-          docker pull ${{ inputs.image }}:${latest}
-          image_digest=`docker inspect --format='{{index .RepoDigests 0}}' ${{ inputs.image }}:${latest} | cut -d'@' -f2`
-          echo "::set-output name=image-digest::$image_digest"
-          echo "::set-output name=image-tag::$latest"
+        request_url="https://${{ inputs.url }}/v2/repositories/${{ inputs.image }}/tags"
+        digest=""
+        for i in $(seq 1 10); do
+            echo "Request: $request_url"
+            response=$(wget -q "${request_url}" -O -)
+            next_url=`echo $response | jq -r '.next'`
+
+            manifest=`echo $response | jq -r '.results | .[] | select(.name=="${{ inputs.tag }}")'`
+            if [[ -n "$manifest" ]]; then
+                echo "Found manifest for tag: ${{ inputs.tag }}"
+                image=`echo $manifest | jq -r '.images | .[] | select(.architecture=="${{ inputs.architecture }}")'`
+                
+                echo $image | jq -r "."
+                digest=`echo $image | jq -r '.digest'`                
+                break;
+            fi
+
+            request_url="$next_url"
+        done
+        echo "::set-output name=image-digest::$digest"
+        if [[ -z "$digest" ]]; then
+            echo "Failed to find digest for $latest"
+            exit 1
+        fi

--- a/.github/actions/docker-image-tag/action.yml
+++ b/.github/actions/docker-image-tag/action.yml
@@ -1,0 +1,26 @@
+name: 'DockerHub Image Tag'
+description: 'Retrieve the latest tag matching the query. Latest is determined by tag ordering.'
+inputs:
+  url:
+    description: 'The docker registry domain'
+    required: true
+  image:
+    description: 'The namespace of the image'
+    required: true
+  query:
+    description: 'The search term for the image tag'
+    required: true
+outputs:
+  image-tag:
+    description: "The image tag"
+    value: ${{ steps.action.outputs.image-tag }}
+runs:
+  using: "composite"
+  steps:
+    - id: action
+      shell: bash
+      run: |
+          request_url="https://${{ inputs.url }}/v1/repositories/${{ inputs.image }}/tags"
+          echo "Request: ${request_url}"
+          latest=$(wget -q "${request_url}" -O - | tr -d '[]" ' | tr '}' '\n' | awk -F: '{print $3}' | grep 'focal-' | sort -rn | head -n1)
+          echo "::set-output name=image-tag::$latest"

--- a/.github/workflows/upgrader.base.yml
+++ b/.github/workflows/upgrader.base.yml
@@ -16,13 +16,21 @@ jobs:
         run: |
           curl -sSL https://github.com/bazelbuild/buildtools/releases/download/3.5.0/buildozer > buildozer
           chmod +x buildozer
+      - name: Find the latest docker tag
+        id: tag
+        uses: ./.github/actions/docker-image-tag
+        with:
+          url: registry.hub.docker.com
+          image: library/ubuntu
+          query: focal-
       - name: Get the docker image sha
-        id: dockerhub
+        id: digest
         uses: ./.github/actions/docker-image-digest
         with:
           url: registry.hub.docker.com
           image: library/ubuntu
-          tag: focal-
+          architecture: amd64
+          tag: ${{ steps.tag.outputs.image-tag }}
       - name: Determine the current image digest
         id: source
         run: |
@@ -30,31 +38,31 @@ jobs:
           echo "::set-output name=image-digest::$image_digest"
       - name: Print the determined image digests
         run: |
-          echo DockerHub digest ${{ steps.dockerhub.outputs.image-digest }}
+          echo DockerHub digest ${{ steps.digest.outputs.image-digest }}
           echo Source digest ${{ steps.source.outputs.image-digest }}
       - name: Configure git
-        if: ${{ steps.dockerhub.outputs.image-digest != steps.source.outputs.image-digest }}
+        if: ${{ steps.digest.outputs.image-digest != steps.source.outputs.image-digest }}
         uses: ./.github/actions/git-config
         with:
           username: jrbeverly
           email: jonathan@jrbeverly.me
-          branch: 'base-image-to-${{ steps.dockerhub.outputs.image-tag }}'
+          branch: 'base-image-to-${{ steps.tag.outputs.image-tag }}'
           token: ${{ secrets.CARDBOARDCI_PAT_TOKEN }}
       - name: Buildozer to edit digest
-        if: ${{ steps.dockerhub.outputs.image-digest != steps.source.outputs.image-digest }}
+        if: ${{ steps.digest.outputs.image-digest != steps.source.outputs.image-digest }}
         run: |
           set -x
-          cat WORKSPACE | ./buildozer 'set digest "${{ steps.dockerhub.outputs.image-digest }}"' "-:ubuntu" | tee WORKSPACE.tmp
+          cat WORKSPACE | ./buildozer 'set digest "${{ steps.digest.outputs.image-digest }}"' "-:ubuntu" | tee WORKSPACE.tmp
           rm WORKSPACE
           mv WORKSPACE.tmp WORKSPACE
           git add -f WORKSPACE
       - name: Commit all of the dependencies
         uses: ./.github/actions/git-commit
-        if: ${{ steps.dockerhub.outputs.image-digest != steps.source.outputs.image-digest && github.ref == 'refs/heads/master' }}
+        if: ${{ steps.digest.outputs.image-digest != steps.source.outputs.image-digest && github.ref == 'refs/heads/master' }}
         env:
           GITHUB_TOKEN: ${{ secrets.CARDBOARDCI_PAT_TOKEN }}
         with:
           username: jrbeverly
-          title: "Bump base image to ${{ steps.dockerhub.outputs.image-tag }} tag"
-          body: "Bumps the base image to `${{ steps.dockerhub.outputs.image-tag }}`.\n\nReplaces the old ubuntu image digest with the latest digest for tag `${{ steps.dockerhub.outputs.image-tag }}`.\n - source-digest: `${{ steps.source.outputs.image-digest }}`\n - tag-digest: `${{ steps.dockerhub.outputs.image-digest }}`"
+          title: "Bump base image to ${{ steps.tag.outputs.image-tag }} tag"
+          body: "Bumps the base image to `${{ steps.tag.outputs.image-tag }}`.\n\nReplaces the old ubuntu image digest with the latest digest for tag `${{ steps.dockerhub.outputs.image-tag }}`.\n - source-digest: `${{ steps.source.outputs.image-digest }}`\n - tag-digest: `${{ steps.dockerhub.outputs.image-digest }}`"
           options: "--label dependencies"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,7 +25,6 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 
 pip_deps()
 
-
 container_pull(
     name = "ubuntu",
     digest = "sha256:3093096ee188f8ff4531949b8f6115af4747ec1c58858c091c8cb4579c39cc4e",


### PR DESCRIPTION
The digest used from docker pull/inspect is incorrect.

Pull the digest from the registry V2 api, and get the latest available tag from the v1 api. This will ensure that the correct digest is passed on to the WORKSPACE file, rather than the digest of the manifest itself.

The selection of the latest tag has been split out to its own action to reduce the complexity in the digest action.