### PR TITLE
legal(license): License is using wrong author

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 CardboardCI
+Copyright (c) 2020 Jonathan Beverly <jrbeverly>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
CardboardCI is just a means of organizing a personal project for determinstic-style docker images.

The organization is just a GitHub Organization and does not have any formal 'organization' status. This should have been licensed under my personal aliases.