### PR TITLE
docs(wrappers): Document design for integrity checks

### DIFF
--- a/images/awscli/BUILD
+++ b/images/awscli/BUILD
@@ -3,19 +3,11 @@ load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "instal
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID")
-load("@cardboardci//rules:packages.bzl", "package_json")
 
 download_pkgs(
     name = "apt_get_download",
     image_tar = "//images/base:image.tar",
     packages = ["awscli"],
-)
-
-package_json(
-    name = "apt_get_awscli",
-    package = "awscli",
-    version = "x.y.z",
-    sum = "123123"
 )
 
 install_pkgs(

--- a/images/awscli/BUILD
+++ b/images/awscli/BUILD
@@ -3,11 +3,19 @@ load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "instal
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "CARDBOARDCI_GID", "CARDBOARDCI_UID")
+load("@cardboardci//rules:packages.bzl", "package_json")
 
 download_pkgs(
     name = "apt_get_download",
     image_tar = "//images/base:image.tar",
     packages = ["awscli"],
+)
+
+package_json(
+    name = "apt_get_awscli",
+    package = "awscli",
+    version = "x.y.z",
+    sum = "123123"
 )
 
 install_pkgs(

--- a/rules/README.md
+++ b/rules/README.md
@@ -1,0 +1,51 @@
+# Sum Verified Rules Investigation
+
+Below is an outline of the design idea for checking the integrity of all packages installed into the docker image, to ensure that the installed package is as expected.
+
+```skylark
+# Define a package file that is used for download/integrity checks
+container_luarocks_package(
+    name = "luarocks_luacheck",
+    package = "luacheck",
+    version = "1.23.0",
+    sum = "4521794f0fba2e20f3bf15846ab5e01d5332e587e9ce81629c7f96c793bb7036",
+)
+
+# Download the luarock packages, with the necessary data to perform
+# integrity checks on the data. The output csv can be used with the
+# json sums to ensure integrity of the downloaded files. Failing on 
+# an integrity check will just be a pain point
+#
+# This outputs a tar, csv and build script
+container_luarocks_download(
+    name = "luarocks_download",
+    image_tar = "//images/downloader:image.tar",
+    packages = [
+        ":luarocks_luacheck",
+        # other dependencies can be added here
+    ]
+)
+
+# docker run :integrity will convert the package files into an
+# index that can be checked by each entry in the downloaded CSVs
+container_package_integrity(
+    name = "integrity",
+    packages = [
+        ":luarocks_luacheck",
+        # ... and other json files
+    ],
+    results = [
+        ":luarocks_download.csv",
+    ]
+)
+
+# The tar file is then installed using the existing package manager
+container_luarocks_install(
+    name = "luarocks_installed",
+    image_tar = "//images/base:image.tar",
+    installables_tar = ":luarocks_download.tar",
+    installation_pre_commands = "",
+    installation_post_commands = "",
+    output_image_name = "luarocks_installed",
+)
+```

--- a/rules/README.md
+++ b/rules/README.md
@@ -1,6 +1,6 @@
 # Sum Verified Rules Investigation
 
-Below is an outline of the design idea for checking the integrity of all packages installed into the docker image, to ensure that the installed package is as expected.
+Below is an outline of the design idea for checking the integrity of all packages installed into the docker image, to ensure that the installed package is as expected. This is a design idea and not implemented into the code at this time.
 
 ```skylark
 # Define a package file that is used for download/integrity checks

--- a/rules/README.md
+++ b/rules/README.md
@@ -2,7 +2,7 @@
 
 Below is an outline of the design idea for checking the integrity of all packages installed into the docker image, to ensure that the installed package is as expected. This is a design idea and not implemented into the code at this time.
 
-```skylark
+```starlark
 # Define a package file that is used for download/integrity checks
 container_luarocks_package(
     name = "luarocks_luacheck",

--- a/rules/packages.bzl
+++ b/rules/packages.bzl
@@ -1,0 +1,36 @@
+"""
+Rules for representing package from package managers.
+"""
+
+load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_commit")
+_PACKAGE_JSON_TEMPLATE = "\"package\": \"{package}\", \"version\": \"{version}\", \"sum\": \"{sum}\""
+
+def _package_json_impl(ctx):
+
+    ctx.actions.write(
+        output = ctx.outputs.manifest,
+        content = "{" + _PACKAGE_JSON_TEMPLATE.format(
+            package = ctx.attr.package,
+            version = ctx.attr.version,
+            sum = ctx.attr.sum,
+        ) + "}",
+    )
+
+package_json = rule(
+    implementation = _package_json_impl,
+    attrs = {
+        "package": attr.string(mandatory = True),
+        "version": attr.string(mandatory = True),
+        "sum": attr.string(mandatory = True),
+    },
+    outputs = {"manifest": "%{name}.json"},
+)
+
+# # Each of these is for something
+# def luacheck_download_and_install(name, image, packages):
+#     commands = ["luarocks install %s" % p for p in packages]
+#     container_run_and_commit(
+#         name = name,
+#         commands = commands,
+#         image = image,
+#     )

--- a/rules/packages.bzl
+++ b/rules/packages.bzl
@@ -3,6 +3,7 @@ Rules for representing package from package managers.
 """
 
 load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_commit")
+
 _PACKAGE_JSON_TEMPLATE = "\"package\": \"{package}\", \"version\": \"{version}\", \"sum\": \"{sum}\""
 
 def _package_json_impl(ctx):
@@ -25,12 +26,3 @@ package_json = rule(
     },
     outputs = {"manifest": "%{name}.json"},
 )
-
-# # Each of these is for something
-# def luacheck_download_and_install(name, image, packages):
-#     commands = ["luarocks install %s" % p for p in packages]
-#     container_run_and_commit(
-#         name = name,
-#         commands = commands,
-#         image = image,
-#     )

--- a/rules/packages.bzl
+++ b/rules/packages.bzl
@@ -2,12 +2,9 @@
 Rules for representing package from package managers.
 """
 
-load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_commit")
-
 _PACKAGE_JSON_TEMPLATE = "\"package\": \"{package}\", \"version\": \"{version}\", \"sum\": \"{sum}\""
 
 def _package_json_impl(ctx):
-
     ctx.actions.write(
         output = ctx.outputs.manifest,
         content = "{" + _PACKAGE_JSON_TEMPLATE.format(


### PR DESCRIPTION
Document the design for integrity checks on downloaded packages.

The bazel rules at present do not verify the integrity of the downloaded dependencies at any step in the process. This is a design for including a mechanism for integrity verification of each of the dependencies. The download process as a single step to avoid potential problems that may be encountered with the underlying package managers.

Integrity is split into its own rule so that downloads do not fail in the event of a bad integrity check.