### PR TITLE
fix(build): Workflows are pushing to wrong repository

### DIFF
--- a/.github/actions/image-tag/action.yml
+++ b/.github/actions/image-tag/action.yml
@@ -7,6 +7,9 @@ inputs:
   repository:
     description: 'Repository name with owner. For example, cardboardci/dockerfiles'
     required: true
+  image:
+    description: 'Image name. For example, ubuntu'
+    required: true
 outputs:
   owner:
     description: "The ghcr.io repository owner. For example, cardboardci"
@@ -28,6 +31,6 @@ runs:
       run: |
         owner=`echo "${{ inputs.repository }}" | cut -d'/' -f1`
         echo ::set-output name=owner::${owner}
-        echo ::set-output name=image::ghcr.io/${owner}/bats
+        echo ::set-output name=image::ghcr.io/${owner}/${{ inputs.image }}
         echo ::set-output name=tag::$(date -u +'%Y%m%d')
         echo ::set-output name=fullname::ghcr.io/${owner}/bats:$(date -u +'%Y%m%d')

--- a/.github/workflows/build.awscli.yml
+++ b/.github/workflows/build.awscli.yml
@@ -29,6 +29,7 @@ jobs:
         id: image
         uses: ./.github/actions/image-tag
         with:
+          image: awscli
           repository: $GITHUB_REPOSITORY
 
       - name: Tag Image

--- a/.github/workflows/build.base.yml
+++ b/.github/workflows/build.base.yml
@@ -27,6 +27,7 @@ jobs:
         id: image
         uses: ./.github/actions/image-tag
         with:
+          image: base
           repository: $GITHUB_REPOSITORY
 
       - name: Tag Image

--- a/.github/workflows/build.bats.yml
+++ b/.github/workflows/build.bats.yml
@@ -29,6 +29,7 @@ jobs:
         id: image
         uses: ./.github/actions/image-tag
         with:
+          image: bats
           repository: $GITHUB_REPOSITORY
 
       - name: Tag Image

--- a/.github/workflows/build.cppcheck.yml
+++ b/.github/workflows/build.cppcheck.yml
@@ -29,6 +29,7 @@ jobs:
         id: image
         uses: ./.github/actions/image-tag
         with:
+          image: cppcheck
           repository: $GITHUB_REPOSITORY
 
       - name: Tag Image

--- a/.github/workflows/build.dbxcli.yml
+++ b/.github/workflows/build.dbxcli.yml
@@ -29,6 +29,7 @@ jobs:
         id: image
         uses: ./.github/actions/image-tag
         with:
+          image: dbxcli
           repository: $GITHUB_REPOSITORY
 
       - name: Tag Image

--- a/.github/workflows/build.ecr.yml
+++ b/.github/workflows/build.ecr.yml
@@ -29,6 +29,7 @@ jobs:
         id: image
         uses: ./.github/actions/image-tag
         with:
+          image: ecr
           repository: $GITHUB_REPOSITORY
 
       - name: Tag Image

--- a/.github/workflows/build.github.yml
+++ b/.github/workflows/build.github.yml
@@ -29,6 +29,7 @@ jobs:
         id: image
         uses: ./.github/actions/image-tag
         with:
+          image: github
           repository: $GITHUB_REPOSITORY
 
       - name: Tag Image

--- a/.github/workflows/build.gitlab.yml
+++ b/.github/workflows/build.gitlab.yml
@@ -29,6 +29,7 @@ jobs:
         id: image
         uses: ./.github/actions/image-tag
         with:
+          image: gitlab
           repository: $GITHUB_REPOSITORY
 
       - name: Tag Image

--- a/.github/workflows/build.hadolint.yml
+++ b/.github/workflows/build.hadolint.yml
@@ -29,6 +29,7 @@ jobs:
         id: image
         uses: ./.github/actions/image-tag
         with:
+          image: hadolint
           repository: $GITHUB_REPOSITORY
 
       - name: Tag Image

--- a/.github/workflows/build.htmlhint.yml
+++ b/.github/workflows/build.htmlhint.yml
@@ -29,6 +29,7 @@ jobs:
         id: image
         uses: ./.github/actions/image-tag
         with:
+          image: htmlhint
           repository: $GITHUB_REPOSITORY
 
       - name: Tag Image

--- a/.github/workflows/build.hugo.yml
+++ b/.github/workflows/build.hugo.yml
@@ -29,6 +29,7 @@ jobs:
         id: image
         uses: ./.github/actions/image-tag
         with:
+          image: hugo
           repository: $GITHUB_REPOSITORY
 
       - name: Tag Image

--- a/.github/workflows/build.luacheck.yml
+++ b/.github/workflows/build.luacheck.yml
@@ -29,6 +29,7 @@ jobs:
         id: image
         uses: ./.github/actions/image-tag
         with:
+          image: luacheck
           repository: $GITHUB_REPOSITORY
 
       - name: Tag Image

--- a/.github/workflows/build.markdownlint.yml
+++ b/.github/workflows/build.markdownlint.yml
@@ -29,6 +29,7 @@ jobs:
         id: image
         uses: ./.github/actions/image-tag
         with:
+          image: markdownlint
           repository: $GITHUB_REPOSITORY
 
       - name: Tag Image

--- a/.github/workflows/build.netlify.yml
+++ b/.github/workflows/build.netlify.yml
@@ -29,6 +29,7 @@ jobs:
         id: image
         uses: ./.github/actions/image-tag
         with:
+          image: netlify
           repository: $GITHUB_REPOSITORY
 
       - name: Tag Image

--- a/.github/workflows/build.pdf2htmlex.yml
+++ b/.github/workflows/build.pdf2htmlex.yml
@@ -28,6 +28,7 @@ jobs:
         id: image
         uses: ./.github/actions/image-tag
         with:
+          image: pdf2htmlex
           repository: $GITHUB_REPOSITORY
 
       - name: Tag Image

--- a/.github/workflows/build.pdftools.yml
+++ b/.github/workflows/build.pdftools.yml
@@ -29,6 +29,7 @@ jobs:
         id: image
         uses: ./.github/actions/image-tag
         with:
+          image: pdftools
           repository: $GITHUB_REPOSITORY
 
       - name: Tag Image

--- a/.github/workflows/build.psscriptanalyzer.yml
+++ b/.github/workflows/build.psscriptanalyzer.yml
@@ -29,6 +29,7 @@ jobs:
         id: image
         uses: ./.github/actions/image-tag
         with:
+          image: psscriptanalyzer
           repository: $GITHUB_REPOSITORY
 
       - name: Tag Image

--- a/.github/workflows/build.pylint.yml
+++ b/.github/workflows/build.pylint.yml
@@ -29,6 +29,7 @@ jobs:
         id: image
         uses: ./.github/actions/image-tag
         with:
+          image: pylint
           repository: $GITHUB_REPOSITORY
 
       - name: Tag Image

--- a/.github/workflows/build.rsvg.yml
+++ b/.github/workflows/build.rsvg.yml
@@ -29,6 +29,7 @@ jobs:
         id: image
         uses: ./.github/actions/image-tag
         with:
+          image: rsvg
           repository: $GITHUB_REPOSITORY
 
       - name: Tag Image

--- a/.github/workflows/build.rubocop.yml
+++ b/.github/workflows/build.rubocop.yml
@@ -29,6 +29,7 @@ jobs:
         id: image
         uses: ./.github/actions/image-tag
         with:
+          image: rubocop
           repository: $GITHUB_REPOSITORY
 
       - name: Tag Image

--- a/.github/workflows/build.shellcheck.yml
+++ b/.github/workflows/build.shellcheck.yml
@@ -29,6 +29,7 @@ jobs:
         id: image
         uses: ./.github/actions/image-tag
         with:
+          image: shellcheck
           repository: $GITHUB_REPOSITORY
 
       - name: Tag Image

--- a/.github/workflows/build.stylelint.yml
+++ b/.github/workflows/build.stylelint.yml
@@ -29,6 +29,7 @@ jobs:
         id: image
         uses: ./.github/actions/image-tag
         with:
+          image: stylelint
           repository: $GITHUB_REPOSITORY
 
       - name: Tag Image

--- a/.github/workflows/build.surge.yml
+++ b/.github/workflows/build.surge.yml
@@ -29,6 +29,7 @@ jobs:
         id: image
         uses: ./.github/actions/image-tag
         with:
+          image: surge
           repository: $GITHUB_REPOSITORY
 
       - name: Tag Image

--- a/.github/workflows/build.svgtools.yml
+++ b/.github/workflows/build.svgtools.yml
@@ -29,6 +29,7 @@ jobs:
         id: image
         uses: ./.github/actions/image-tag
         with:
+          image: svgtools
           repository: $GITHUB_REPOSITORY
 
       - name: Tag Image

--- a/.github/workflows/build.tflint.yml
+++ b/.github/workflows/build.tflint.yml
@@ -29,6 +29,7 @@ jobs:
         id: image
         uses: ./.github/actions/image-tag
         with:
+          image: tflint
           repository: $GITHUB_REPOSITORY
 
       - name: Tag Image

--- a/.github/workflows/build.wkhtmltopdf.yml
+++ b/.github/workflows/build.wkhtmltopdf.yml
@@ -29,6 +29,7 @@ jobs:
         id: image
         uses: ./.github/actions/image-tag
         with:
+          image: wkhtmltopdf
           repository: $GITHUB_REPOSITORY
 
       - name: Tag Image


### PR DESCRIPTION
Workflows are all pushing to the `bats` repository, which is incorrect.

This fixes that by switching them all to specify their image name.