### PR TITLE
feat(website): Build website with bazel

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -24,7 +24,6 @@ jobs:
         run: |
           cp bazel-bin/docs/website/website.tar .
           tar -xf website.tar
-          ls public/
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@releases/v3
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,4 +1,4 @@
-name: "Build and Deploy"
+name: "Website - Build & Deploy"
 on:
   push:
     paths:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -17,14 +17,18 @@ jobs:
         working-directory: images/
         run: |
           for x in *; do cp ${x}/README.md ${GITHUB_WORKSPACE}/docs/www/images/${x}.md ; done
-      - name: Mkdocs
-        uses: docker://squidfunk/mkdocs-material@sha256:5282540ecb411db49a2ae3ccea3b00a0ab1f55ecd8151e2941cf0ccad69d2beb
-        with:
-          args: "build --config-file docs/mkdocs.yml --site-dir public"
+      - name: Copy to docs directory
+        run: |
+          bazel build //docs:website
+      - name: Copy to docs directory
+        run: |
+          cp bazel-bin/docs/website/website.tar .
+          tar -xf website.tar
+          ls public/
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@releases/v3
         if: github.ref == 'refs/heads/master'
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
-          FOLDER: docs/public
+          FOLDER: public

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,7 +25,6 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 
 pip_deps()
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "rules_pkg",
     url = "https://github.com/bazelbuild/rules_pkg/releases/download/0.3.0/rules_pkg-0.3.0.tar.gz",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,9 +25,25 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 
 pip_deps()
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "rules_pkg",
+    url = "https://github.com/bazelbuild/rules_pkg/releases/download/0.3.0/rules_pkg-0.3.0.tar.gz",
+    sha256 = "6b5969a7acd7b60c02f816773b06fcf32fbe8ba0c7919ccdc2df4f8fb923804a",
+)
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+rules_pkg_dependencies()
+
 container_pull(
     name = "ubuntu",
     digest = "sha256:3093096ee188f8ff4531949b8f6115af4747ec1c58858c091c8cb4579c39cc4e",
     registry = "index.docker.io",
     repository = "library/ubuntu",
+)
+
+container_pull(
+    name = "mkdocs",
+    digest = "sha256:714cf5b001f7b4ce36b4ee88b85d8e65274445a11e252f0419820b78fbde4ddf",
+    registry = "index.docker.io",
+    repository = "squidfunk/mkdocs-material",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,10 +27,12 @@ pip_deps()
 
 http_archive(
     name = "rules_pkg",
-    url = "https://github.com/bazelbuild/rules_pkg/releases/download/0.3.0/rules_pkg-0.3.0.tar.gz",
     sha256 = "6b5969a7acd7b60c02f816773b06fcf32fbe8ba0c7919ccdc2df4f8fb923804a",
+    url = "https://github.com/bazelbuild/rules_pkg/releases/download/0.3.0/rules_pkg-0.3.0.tar.gz",
 )
+
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+
 rules_pkg_dependencies()
 
 container_pull(

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -1,5 +1,3 @@
-load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
-load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_extract")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
@@ -18,22 +16,6 @@ container_image(
     entrypoint = "",
 )
 
-# download_pkgs(
-#     name = "apt_get_download",
-#     image_tar = ":packaged_mkdocs.tar",
-#     packages = [
-#         "zip","unzip",
-#     ],
-# )
-
-# install_pkgs(
-#     name = "apt_get_installed",
-#     image_tar = ":packaged_mkdocs.tar",
-#     installables_tar = ":apt_get_download.tar",
-#     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
-#     output_image_name = "apt_get_installed",
-# )
-
 container_run_and_extract( 
     name = "website",
     commands = [
@@ -46,5 +28,4 @@ container_run_and_extract(
     ],
     extract_file = "/website.tar",
     image = ":packaged_mkdocs.tar",
-    # image = ":apt_get_installed.tar",
 )

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -1,0 +1,50 @@
+load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
+load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_extract")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+
+pkg_tar(
+    name = "website_contents",
+    srcs = ["mkdocs.yml"] + glob(["www/**/*", "public/**/*"]),
+    strip_prefix = ".",
+)
+
+container_image(
+    name = "packaged_mkdocs",
+    base = "@mkdocs//image",
+    tars = [":website_contents"],
+    cmd = ["/bin/bash"],
+    entrypoint = "",
+)
+
+# download_pkgs(
+#     name = "apt_get_download",
+#     image_tar = ":packaged_mkdocs.tar",
+#     packages = [
+#         "zip","unzip",
+#     ],
+# )
+
+# install_pkgs(
+#     name = "apt_get_installed",
+#     image_tar = ":packaged_mkdocs.tar",
+#     installables_tar = ":apt_get_download.tar",
+#     installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
+#     output_image_name = "apt_get_installed",
+# )
+
+container_run_and_extract(
+    name = "website",
+    commands = [
+        "mkdocs build --config-file /mkdocs.yml --site-dir /public",
+        "tar -cvf /website.tar /public/.",
+    ],
+    docker_run_flags = [
+        "-u",
+        "root",
+    ],
+    extract_file = "/website.tar",
+    image = ":packaged_mkdocs.tar",
+    # image = ":apt_get_installed.tar",
+)

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -4,19 +4,22 @@ load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 pkg_tar(
     name = "website_contents",
-    srcs = ["mkdocs.yml"] + glob(["www/**/*", "public/**/*"]),
+    srcs = ["mkdocs.yml"] + glob([
+        "www/**/*",
+        "public/**/*",
+    ]),
     strip_prefix = ".",
 )
 
 container_image(
     name = "packaged_mkdocs",
     base = "@mkdocs//image",
-    tars = [":website_contents"],
     cmd = ["/bin/bash"],
     entrypoint = "",
+    tars = [":website_contents"],
 )
 
-container_run_and_extract( 
+container_run_and_extract(
     name = "website",
     commands = [
         "mkdocs build --config-file /mkdocs.yml --site-dir /public",

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -34,7 +34,7 @@ container_image(
 #     output_image_name = "apt_get_installed",
 # )
 
-container_run_and_extract(
+container_run_and_extract( 
     name = "website",
     commands = [
         "mkdocs build --config-file /mkdocs.yml --site-dir /public",

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -7,18 +7,21 @@ docs_dir: www
 
 theme:
   name: 'material'
-  # icon: 
-  #   logo: assets/icon.png
+  logo: assets/logo.png
   favicon: assets/favicon.png
   language: 'en'
   palette:
     primary: 'blue'
     accent: 'white'
 
-# extra:
-#   search:
-#     lang:
-#       - en
-#   social:
-#     - icon: 'github'
-#       link: 'https://github.com/cardboardci'
+plugins:
+  - search:
+      lang: en
+
+extra:
+  search:
+    lang:
+      - en
+  social:
+    - icon: 'fontawesome/brands/github'
+      link: 'https://github.com/cardboardci'

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -7,15 +7,18 @@ docs_dir: www
 
 theme:
   name: 'material'
-  logo: assets/icon.png
+  # icon: 
+  #   logo: assets/icon.png
   favicon: assets/favicon.png
   language: 'en'
   palette:
     primary: 'blue'
     accent: 'white'
-extra:
-  search:
-    language: 'en'
-  social:
-    - type: 'github'
-      link: 'https://github.com/cardboardci'
+
+# extra:
+#   search:
+#     lang:
+#       - en
+#   social:
+#     - icon: 'github'
+#       link: 'https://github.com/cardboardci'

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -7,7 +7,7 @@ docs_dir: www
 
 theme:
   name: 'material'
-  logo: assets/logo.png
+  logo: assets/icon.png
   favicon: assets/favicon.png
   language: 'en'
   palette:


### PR DESCRIPTION
Build the website using bazel instead of custom docker.

This switches the website build from using github actions, to using bazel for performing the website construction using mkdocs.