### PR TITLE
add(label): Add edge label to all of the docker images

### DIFF
--- a/.github/workflows/build.awscli.yml
+++ b/.github/workflows/build.awscli.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           bazel run //images/awscli:image
           docker tag bazel/images/awscli:image ${{ steps.image.outputs.fullname }}
+          docker tag bazel/images/awscli:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.base.yml
+++ b/.github/workflows/build.base.yml
@@ -35,6 +35,7 @@ jobs:
         run: |
           bazel run //images/base:image
           docker tag bazel/images/base:image ${{ steps.image.outputs.fullname }}
+          docker tag bazel/images/base:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.bats.yml
+++ b/.github/workflows/build.bats.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           bazel run //images/bats:image
           docker tag bazel/images/bats:image ${{ steps.image.outputs.fullname }}
+          docker tag bazel/images/bats:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.cppcheck.yml
+++ b/.github/workflows/build.cppcheck.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           bazel run //images/cppcheck:image
           docker tag bazel/images/cppcheck:image ${{ steps.image.outputs.fullname }}
+          docker tag bazel/images/cppcheck:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.dbxcli.yml
+++ b/.github/workflows/build.dbxcli.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           bazel run //images/dbxcli:image
           docker tag bazel/images/dbxcli:image ${{ steps.image.outputs.fullname }}
+          docker tag bazel/images/dbxcli:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.ecr.yml
+++ b/.github/workflows/build.ecr.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           bazel run //images/ecr:image
           docker tag bazel/images/ecr:image ${{ steps.image.outputs.fullname }}
+          docker tag bazel/images/ecr:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.github.yml
+++ b/.github/workflows/build.github.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           bazel run //images/github:image
           docker tag bazel/images/github:image ${{ steps.image.outputs.fullname }}
+          docker tag bazel/images/github:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.gitlab.yml
+++ b/.github/workflows/build.gitlab.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           bazel run //images/gitlab:image
           docker tag bazel/images/gitlab:image ${{ steps.image.outputs.fullname }}
+          docker tag bazel/images/gitlab:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.hadolint.yml
+++ b/.github/workflows/build.hadolint.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           bazel run //images/hadolint:image
           docker tag bazel/images/hadolint:image ${{ steps.image.outputs.fullname }}
+          docker tag bazel/images/hadolint:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.htmlhint.yml
+++ b/.github/workflows/build.htmlhint.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           bazel run //images/htmlhint:image
           docker tag bazel/images/htmlhint:image ${{ steps.image.outputs.fullname }}
+          docker tag bazel/images/htmlhint:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.hugo.yml
+++ b/.github/workflows/build.hugo.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           bazel run //images/hugo:image
           docker tag bazel/images/hugo:image ${{ steps.image.outputs.fullname }}
+          docker tag bazel/images/hugo:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.luacheck.yml
+++ b/.github/workflows/build.luacheck.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           bazel run //images/luacheck:image
           docker tag bazel/images/luacheck:image ${{ steps.image.outputs.fullname }}
+          docker tag bazel/images/luacheck:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.markdownlint.yml
+++ b/.github/workflows/build.markdownlint.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           bazel run //images/markdownlint:image
           docker tag bazel/images/markdownlint:image ${{ steps.image.outputs.fullname }}
+          docker tag bazel/images/markdownlint:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.netlify.yml
+++ b/.github/workflows/build.netlify.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           bazel run //images/netlify:image
           docker tag bazel/images/netlify:image ${{ steps.image.outputs.fullname }}
+          docker tag bazel/images/netlify:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.pdf2htmlex.yml
+++ b/.github/workflows/build.pdf2htmlex.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           bazel run //images/pdf2htmlex:image
           docker tag bazel/images/pdf2htmlex:image ${{ steps.image.outputs.fullname }}
+          docker tag bazel/images/pdf2htmlex:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.pdftools.yml
+++ b/.github/workflows/build.pdftools.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           bazel run //images/pdftools:image
           docker tag bazel/images/pdftools:image ${{ steps.image.outputs.fullname }}
+          docker tag bazel/images/pdftools:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.psscriptanalyzer.yml
+++ b/.github/workflows/build.psscriptanalyzer.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           bazel run //images/psscriptanalyzer:image
           docker tag bazel/images/psscriptanalyzer:image ${{ steps.image.outputs.fullname }}
+          docker tag bazel/images/psscriptanalyzer:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.pylint.yml
+++ b/.github/workflows/build.pylint.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           bazel run //images/pylint:image
           docker tag bazel/images/pylint:image ${{ steps.image.outputs.fullname }}
+          docker tag bazel/images/pylint:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.rsvg.yml
+++ b/.github/workflows/build.rsvg.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           bazel run //images/rsvg:image
           docker tag bazel/images/rsvg:image ${{ steps.image.outputs.fullname }}
+          docker tag bazel/images/rsvg:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.rubocop.yml
+++ b/.github/workflows/build.rubocop.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           bazel run //images/rubocop:image
           docker tag bazel/images/rubocop:image ${{ steps.image.outputs.fullname }}
+          docker tag bazel/images/rubocop:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.shellcheck.yml
+++ b/.github/workflows/build.shellcheck.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           bazel run //images/shellcheck:image
           docker tag bazel/images/shellcheck:image ${{ steps.image.outputs.fullname }}
+          docker tag bazel/images/shellcheck:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.stylelint.yml
+++ b/.github/workflows/build.stylelint.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           bazel run //images/stylelint:image
           docker tag bazel/images/stylelint:image ${{ steps.image.outputs.fullname }}
+          docker tag bazel/images/stylelint:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.surge.yml
+++ b/.github/workflows/build.surge.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           bazel run //images/surge:image
           docker tag bazel/images/surge:image ${{ steps.image.outputs.fullname }}
+          docker tag bazel/images/surge:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.svgtools.yml
+++ b/.github/workflows/build.svgtools.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           bazel run //images/svgtools:image
           docker tag bazel/images/svgtools:image ${{ steps.image.outputs.fullname }}
+          docker tag bazel/images/svgtools:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.tflint.yml
+++ b/.github/workflows/build.tflint.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           bazel run //images/tflint:image
           docker tag bazel/images/tflint:image ${{ steps.image.outputs.fullname }}
+          docker tag bazel/images/tflint:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.wkhtmltopdf.yml
+++ b/.github/workflows/build.wkhtmltopdf.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           bazel run //images/wkhtmltopdf:image
           docker tag bazel/images/wkhtmltopdf:image ${{ steps.image.outputs.fullname }}
+          docker tag bazel/images/wkhtmltopdf:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
Add the edge label to all the docker images, making it easier to `docker pull` the latest.

This is done to make it easier to use `docker pull` to retrieve the latest image, with a different naming convention to express the desire that a tag or digest based approach is a better model.