### PR TITLE
add(tests): Ensure all images are tested the same

### DIFF
--- a/images/awscli/BUILD
+++ b/images/awscli/BUILD
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:images.bzl", "cardboardci_image")
+load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(
     name = "apt_get_download",
@@ -27,12 +27,10 @@ cardboardci_image(
     },
 )
 
-container_test(
+cardboardci_test(
     name = "test",
     configs = [
         "//images/awscli/test_configs:command.yaml",
-        "//tests:limited_user.yaml",
-        "//tests:metadata.yaml",
     ],
     image = ":image",
 )

--- a/images/awscli/BUILD
+++ b/images/awscli/BUILD
@@ -1,6 +1,5 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(

--- a/images/bats/BUILD
+++ b/images/bats/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "npm_download_and_install")
-load("@cardboardci//rules:images.bzl", "cardboardci_image")
+load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(
     name = "apt_get_download",
@@ -39,12 +39,10 @@ cardboardci_image(
     },
 )
 
-container_test(
+cardboardci_test(
     name = "test",
     configs = [
         "//images/bats/test_configs:command.yaml",
-        "//tests:limited_user.yaml",
-        "//tests:metadata.yaml",
     ],
     image = ":image",
 )

--- a/images/bats/BUILD
+++ b/images/bats/BUILD
@@ -1,6 +1,5 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "npm_download_and_install")
 load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 

--- a/images/cppcheck/BUILD
+++ b/images/cppcheck/BUILD
@@ -1,6 +1,5 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(

--- a/images/cppcheck/BUILD
+++ b/images/cppcheck/BUILD
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:images.bzl", "cardboardci_image")
+load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(
     name = "apt_get_download",
@@ -33,12 +33,10 @@ cardboardci_image(
     },
 )
 
-container_test(
+cardboardci_test(
     name = "test",
     configs = [
         "//images/cppcheck/test_configs:command.yaml",
-        "//tests:limited_user.yaml",
-        "//tests:metadata.yaml",
     ],
     image = ":image",
 )

--- a/images/dbxcli/BUILD
+++ b/images/dbxcli/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "binary_download_and_install")
-load("@cardboardci//rules:images.bzl", "cardboardci_image")
+load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(
     name = "apt_get_download",
@@ -35,12 +35,10 @@ cardboardci_image(
     },
 )
 
-container_test(
+cardboardci_test(
     name = "test",
     configs = [
         "//images/dbxcli/test_configs:command.yaml",
-        "//tests:limited_user.yaml",
-        "//tests:metadata.yaml",
     ],
     image = ":image",
 )

--- a/images/dbxcli/BUILD
+++ b/images/dbxcli/BUILD
@@ -1,6 +1,5 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "binary_download_and_install")
 load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 

--- a/images/ecr/BUILD
+++ b/images/ecr/BUILD
@@ -1,6 +1,5 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(

--- a/images/ecr/BUILD
+++ b/images/ecr/BUILD
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:images.bzl", "cardboardci_image")
+load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(
     name = "apt_get_download",
@@ -30,12 +30,10 @@ cardboardci_image(
     },
 )
 
-container_test(
+cardboardci_test(
     name = "test",
     configs = [
         "//images/ecr/test_configs:command.yaml",
-        "//tests:limited_user.yaml",
-        "//tests:metadata.yaml",
     ],
     image = ":image",
 )

--- a/images/github/BUILD
+++ b/images/github/BUILD
@@ -1,8 +1,7 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "deb_download_and_install")
-load("@cardboardci//rules:images.bzl", "cardboardci_image")
+load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(
     name = "apt_get_download",
@@ -40,12 +39,10 @@ cardboardci_image(
     },
 )
 
-container_test(
+cardboardci_test(
     name = "test",
     configs = [
         "//images/github/test_configs:command.yaml",
-        "//tests:limited_user.yaml",
-        "//tests:metadata.yaml",
     ],
     image = ":image",
 )

--- a/images/gitlab/BUILD
+++ b/images/gitlab/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_commit")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:images.bzl", "cardboardci_image")
+load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(
     name = "apt_get_download",
@@ -46,12 +46,10 @@ cardboardci_image(
     },
 )
 
-container_test(
+cardboardci_test(
     name = "test",
     configs = [
         "//images/gitlab/test_configs:command.yaml",
-        "//tests:limited_user.yaml",
-        "//tests:metadata.yaml",
     ],
     image = ":image",
 )

--- a/images/gitlab/BUILD
+++ b/images/gitlab/BUILD
@@ -1,7 +1,6 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_commit")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(

--- a/images/hadolint/BUILD
+++ b/images/hadolint/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "binary_download_and_install")
-load("@cardboardci//rules:images.bzl", "cardboardci_image")
+load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(
     name = "apt_get_download",
@@ -38,12 +38,10 @@ cardboardci_image(
     },
 )
 
-container_test(
+cardboardci_test(
     name = "test",
     configs = [
         "//images/hadolint/test_configs:command.yaml",
-        "//tests:limited_user.yaml",
-        "//tests:metadata.yaml",
     ],
     image = ":image",
 )

--- a/images/hadolint/BUILD
+++ b/images/hadolint/BUILD
@@ -1,6 +1,5 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "binary_download_and_install")
 load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 

--- a/images/htmlhint/BUILD
+++ b/images/htmlhint/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "npm_download_and_install")
-load("@cardboardci//rules:images.bzl", "cardboardci_image")
+load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(
     name = "apt_get_download",
@@ -39,12 +39,10 @@ cardboardci_image(
     },
 )
 
-container_test(
+cardboardci_test(
     name = "test",
     configs = [
         "//images/htmlhint/test_configs:command.yaml",
-        "//tests:limited_user.yaml",
-        "//tests:metadata.yaml",
     ],
     image = ":image",
 )

--- a/images/htmlhint/BUILD
+++ b/images/htmlhint/BUILD
@@ -1,6 +1,5 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "npm_download_and_install")
 load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 

--- a/images/hugo/BUILD
+++ b/images/hugo/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "deb_download_and_install")
-load("@cardboardci//rules:images.bzl", "cardboardci_image")
+load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(
     name = "apt_get_download",
@@ -40,12 +40,10 @@ cardboardci_image(
     },
 )
 
-container_test(
+cardboardci_test(
     name = "test",
     configs = [
         "//images/hugo/test_configs:command.yaml",
-        "//tests:limited_user.yaml",
-        "//tests:metadata.yaml",
     ],
     image = ":image",
 )

--- a/images/hugo/BUILD
+++ b/images/hugo/BUILD
@@ -1,6 +1,5 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "deb_download_and_install")
 load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 

--- a/images/luacheck/BUILD
+++ b/images/luacheck/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "luacheck_download_and_install")
-load("@cardboardci//rules:images.bzl", "cardboardci_image")
+load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(
     name = "apt_get_download",
@@ -40,12 +40,10 @@ cardboardci_image(
     },
 )
 
-container_test(
+cardboardci_test(
     name = "test",
     configs = [
         "//images/luacheck/test_configs:command.yaml",
-        "//tests:limited_user.yaml",
-        "//tests:metadata.yaml",
     ],
     image = ":image",
 )

--- a/images/luacheck/BUILD
+++ b/images/luacheck/BUILD
@@ -1,6 +1,5 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "luacheck_download_and_install")
 load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 

--- a/images/markdownlint/BUILD
+++ b/images/markdownlint/BUILD
@@ -1,6 +1,5 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "npm_download_and_install")
 load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 

--- a/images/markdownlint/BUILD
+++ b/images/markdownlint/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "npm_download_and_install")
-load("@cardboardci//rules:images.bzl", "cardboardci_image")
+load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(
     name = "apt_get_download",
@@ -39,12 +39,10 @@ cardboardci_image(
     },
 )
 
-container_test(
+cardboardci_test(
     name = "test",
     configs = [
         "//images/markdownlint/test_configs:command.yaml",
-        "//tests:limited_user.yaml",
-        "//tests:metadata.yaml",
     ],
     image = ":image",
 )

--- a/images/netlify/BUILD
+++ b/images/netlify/BUILD
@@ -1,6 +1,5 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "npm_download_and_install")
 load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 

--- a/images/netlify/BUILD
+++ b/images/netlify/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "npm_download_and_install")
-load("@cardboardci//rules:images.bzl", "cardboardci_image")
+load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(
     name = "apt_get_download",
@@ -39,12 +39,10 @@ cardboardci_image(
     },
 )
 
-container_test(
+cardboardci_test(
     name = "test",
     configs = [
         "//images/netlify/test_configs:command.yaml",
-        "//tests:limited_user.yaml",
-        "//tests:metadata.yaml",
     ],
     image = ":image",
 )

--- a/images/pdf2htmlex/BUILD
+++ b/images/pdf2htmlex/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "deb_download_and_install")
-load("@cardboardci//rules:images.bzl", "cardboardci_image")
+load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(
     name = "apt_get_download",
@@ -57,12 +57,10 @@ cardboardci_image(
     },
 )
 
-container_test(
+cardboardci_test(
     name = "test",
     configs = [
         "//images/pdf2htmlex/test_configs:command.yaml",
-        "//tests:limited_user.yaml",
-        "//tests:metadata.yaml",
     ],
     image = ":image",
 )

--- a/images/pdf2htmlex/BUILD
+++ b/images/pdf2htmlex/BUILD
@@ -1,6 +1,5 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "deb_download_and_install")
 load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 

--- a/images/pdftools/BUILD
+++ b/images/pdftools/BUILD
@@ -1,6 +1,5 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(

--- a/images/pdftools/BUILD
+++ b/images/pdftools/BUILD
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:images.bzl", "cardboardci_image")
+load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(
     name = "apt_get_download",
@@ -27,12 +27,10 @@ cardboardci_image(
     },
 )
 
-container_test(
+cardboardci_test(
     name = "test",
     configs = [
         "//images/pdftools/test_configs:command.yaml",
-        "//tests:limited_user.yaml",
-        "//tests:metadata.yaml",
     ],
     image = ":image",
 )

--- a/images/psscriptanalyzer/BUILD
+++ b/images/psscriptanalyzer/BUILD
@@ -2,7 +2,6 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_commit")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 

--- a/images/psscriptanalyzer/BUILD
+++ b/images/psscriptanalyzer/BUILD
@@ -3,7 +3,7 @@ load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "instal
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_commit")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:images.bzl", "cardboardci_image")
+load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 download_pkgs(
@@ -73,12 +73,10 @@ cardboardci_image(
     tars = [":scripts"],
 )
 
-container_test(
+cardboardci_test(
     name = "test",
     configs = [
         "//images/psscriptanalyzer/test_configs:command.yaml",
-        "//tests:limited_user.yaml",
-        "//tests:metadata.yaml",
     ],
     image = ":image",
 )

--- a/images/pylint/BUILD
+++ b/images/pylint/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "pip_download_and_install")
-load("@cardboardci//rules:images.bzl", "cardboardci_image")
+load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(
     name = "apt_get_download",
@@ -39,12 +39,10 @@ cardboardci_image(
     },
 )
 
-container_test(
+cardboardci_test(
     name = "test",
     configs = [
         "//images/pylint/test_configs:command.yaml",
-        "//tests:limited_user.yaml",
-        "//tests:metadata.yaml",
     ],
     image = ":image",
 )

--- a/images/pylint/BUILD
+++ b/images/pylint/BUILD
@@ -1,6 +1,5 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "pip_download_and_install")
 load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 

--- a/images/rsvg/BUILD
+++ b/images/rsvg/BUILD
@@ -1,6 +1,5 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(

--- a/images/rsvg/BUILD
+++ b/images/rsvg/BUILD
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:images.bzl", "cardboardci_image")
+load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(
     name = "apt_get_download",
@@ -27,12 +27,10 @@ cardboardci_image(
     },
 )
 
-container_test(
+cardboardci_test(
     name = "test",
     configs = [
         "//images/rsvg/test_configs:command.yaml",
-        "//tests:limited_user.yaml",
-        "//tests:metadata.yaml",
     ],
     image = ":image",
 )

--- a/images/rubocop/BUILD
+++ b/images/rubocop/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "gem_download_and_install")
-load("@cardboardci//rules:images.bzl", "cardboardci_image")
+load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(
     name = "apt_get_download",
@@ -39,12 +39,10 @@ cardboardci_image(
     },
 )
 
-container_test(
+cardboardci_test(
     name = "test",
     configs = [
         "//images/rubocop/test_configs:command.yaml",
-        "//tests:limited_user.yaml",
-        "//tests:metadata.yaml",
     ],
     image = ":image",
 )

--- a/images/rubocop/BUILD
+++ b/images/rubocop/BUILD
@@ -1,6 +1,5 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "gem_download_and_install")
 load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 

--- a/images/shellcheck/BUILD
+++ b/images/shellcheck/BUILD
@@ -1,6 +1,5 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(

--- a/images/shellcheck/BUILD
+++ b/images/shellcheck/BUILD
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:images.bzl", "cardboardci_image")
+load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(
     name = "apt_get_download",
@@ -27,12 +27,10 @@ cardboardci_image(
     },
 )
 
-container_test(
+cardboardci_test(
     name = "test",
     configs = [
         "//images/shellcheck/test_configs:command.yaml",
-        "//tests:limited_user.yaml",
-        "//tests:metadata.yaml",
     ],
     image = ":image",
 )

--- a/images/stylelint/BUILD
+++ b/images/stylelint/BUILD
@@ -1,6 +1,5 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "npm_download_and_install")
 load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 

--- a/images/stylelint/BUILD
+++ b/images/stylelint/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "npm_download_and_install")
-load("@cardboardci//rules:images.bzl", "cardboardci_image")
+load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(
     name = "apt_get_download",
@@ -40,12 +40,10 @@ cardboardci_image(
     },
 )
 
-container_test(
+cardboardci_test(
     name = "test",
     configs = [
         "//images/stylelint/test_configs:command.yaml",
-        "//tests:limited_user.yaml",
-        "//tests:metadata.yaml",
     ],
     image = ":image",
 )

--- a/images/surge/BUILD
+++ b/images/surge/BUILD
@@ -39,12 +39,10 @@ cardboardci_image(
     },
 )
 
-container_test(
+cardboardci_test(
     name = "test",
     configs = [
         "//images/surge/test_configs:command.yaml",
-        "//tests:limited_user.yaml",
-        "//tests:metadata.yaml",
     ],
     image = ":image",
 )

--- a/images/surge/BUILD
+++ b/images/surge/BUILD
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@cardboardci//rules:wrappers.bzl", "npm_download_and_install")
-load("@cardboardci//rules:images.bzl", "cardboardci_image")
+load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(
     name = "apt_get_download",

--- a/images/surge/BUILD
+++ b/images/surge/BUILD
@@ -1,6 +1,5 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "npm_download_and_install")
 load("@cardboardci//rules:images.bzl", "cardboardci_image")
 

--- a/images/svgtools/BUILD
+++ b/images/svgtools/BUILD
@@ -1,6 +1,5 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(

--- a/images/svgtools/BUILD
+++ b/images/svgtools/BUILD
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
-load("@cardboardci//rules:images.bzl", "cardboardci_image")
+load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(
     name = "apt_get_download",
@@ -30,12 +30,10 @@ cardboardci_image(
     },
 )
 
-container_test(
+cardboardci_test(
     name = "test",
     configs = [
         "//images/svgtools/test_configs:command.yaml",
-        "//tests:limited_user.yaml",
-        "//tests:metadata.yaml",
     ],
     image = ":image",
 )

--- a/images/tflint/BUILD
+++ b/images/tflint/BUILD
@@ -1,6 +1,5 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "zip_download_and_install")
 load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 

--- a/images/tflint/BUILD
+++ b/images/tflint/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "zip_download_and_install")
-load("@cardboardci//rules:images.bzl", "cardboardci_image")
+load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(
     name = "apt_get_download",
@@ -38,12 +38,10 @@ cardboardci_image(
     },
 )
 
-container_test(
+cardboardci_test(
     name = "test",
     configs = [
         "//images/tflint/test_configs:command.yaml",
-        "//tests:limited_user.yaml",
-        "//tests:metadata.yaml",
     ],
     image = ":image",
 )

--- a/images/wkhtmltopdf/BUILD
+++ b/images/wkhtmltopdf/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "downl
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
 load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "deb_download_and_install")
-load("@cardboardci//rules:images.bzl", "cardboardci_image")
+load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 
 download_pkgs(
     name = "apt_get_download",
@@ -51,12 +51,10 @@ cardboardci_image(
     },
 )
 
-container_test(
+cardboardci_test(
     name = "test",
     configs = [
         "//images/wkhtmltopdf/test_configs:command.yaml",
-        "//tests:limited_user.yaml",
-        "//tests:metadata.yaml",
     ],
     image = ":image",
 )

--- a/images/wkhtmltopdf/BUILD
+++ b/images/wkhtmltopdf/BUILD
@@ -1,6 +1,5 @@
 load("@io_bazel_rules_docker//docker/package_managers:download_pkgs.bzl", "download_pkgs")
 load("@io_bazel_rules_docker//docker/package_managers:install_pkgs.bzl", "install_pkgs")
-load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 load("@cardboardci//rules:wrappers.bzl", "deb_download_and_install")
 load("@cardboardci//rules:images.bzl", "cardboardci_image", "cardboardci_test")
 

--- a/rules/images.bzl
+++ b/rules/images.bzl
@@ -3,6 +3,7 @@ Definitions for the image to ensure consistency.
 """
 
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 CARDBOARDCI_UID = "180000"
 CARDBOARDCI_GID = "180000"

--- a/rules/images.bzl
+++ b/rules/images.bzl
@@ -40,3 +40,14 @@ def cardboardci_image(name, base, labels, tars = []):
         ],
         workdir = "/workspace",
     )
+
+def cardboardci_test(name, image, configs = []):
+    container_test(
+        name = name,
+        configs = [
+            "//tests:limited_user.yaml",
+            "//tests:metadata.yaml",
+            "//tests:essentials.yaml",
+        ] + configs,
+        image = image,
+    )

--- a/tests/essentials.yaml
+++ b/tests/essentials.yaml
@@ -1,0 +1,19 @@
+schemaVersion: 2.0.0
+
+commandTests:
+    - name: "jq"
+      command: "jq"
+      args: ["--version"]
+      expectedOutput: ["jq-\\d+\\..*"]
+    - name: "bash"
+      command: "bash"
+      args: ["--version"]
+      expectedOutput: ["GNU bash, version \\d+\\..*"]
+    - name: "git"
+      command: "git"
+      args: ["--version"]
+      expectedOutput: ["git version \\d+\\..*"]
+    - name: "curl"
+      command: "curl"
+      args: ["--version"]
+      expectedOutput: ["curl \\d+\\..*"]


### PR DESCRIPTION
Add a wrapper responsible for ensuring all of the images received the same tests.

This ensures that any of the common root level tests that all images must meet are upheld by each of the images.