### PR TITLE
docs(images): Standard template for all images

### DIFF
--- a/.github/workflows/build.awscli.yml
+++ b/.github/workflows/build.awscli.yml
@@ -9,8 +9,9 @@ on:
       - images/awscli/BUILD
       - WORKSPACE
       - rules/*.bzl
-      - images/base/*
-      - images/base/**/*
+      - images/base/image_data/**/*
+      - images/base/test_configs/**/*
+      - images/base/BUILD
       - tests/*.yaml
 
 jobs:

--- a/.github/workflows/build.bats.yml
+++ b/.github/workflows/build.bats.yml
@@ -9,8 +9,9 @@ on:
       - images/bats/BUILD
       - WORKSPACE
       - rules/images.bzl
-      - images/base/*
-      - images/base/**/*
+      - images/base/image_data/**/*
+      - images/base/test_configs/**/*
+      - images/base/BUILD
       - tests/*.yaml
 
 jobs:

--- a/.github/workflows/build.cppcheck.yml
+++ b/.github/workflows/build.cppcheck.yml
@@ -9,8 +9,9 @@ on:
       - images/cppcheck/BUILD
       - WORKSPACE
       - rules/images.bzl
-      - images/base/*
-      - images/base/**/*
+      - images/base/image_data/**/*
+      - images/base/test_configs/**/*
+      - images/base/BUILD
       - tests/*.yaml
 
 jobs:

--- a/.github/workflows/build.dbxcli.yml
+++ b/.github/workflows/build.dbxcli.yml
@@ -9,8 +9,9 @@ on:
       - images/dbxcli/BUILD
       - WORKSPACE
       - rules/images.bzl
-      - images/base/*
-      - images/base/**/*
+      - images/base/image_data/**/*
+      - images/base/test_configs/**/*
+      - images/base/BUILD
       - tests/*.yaml
 
 jobs:

--- a/.github/workflows/build.ecr.yml
+++ b/.github/workflows/build.ecr.yml
@@ -9,8 +9,9 @@ on:
       - images/ecr/BUILD
       - WORKSPACE
       - rules/images.bzl
-      - images/base/*
-      - images/base/**/*
+      - images/base/image_data/**/*
+      - images/base/test_configs/**/*
+      - images/base/BUILD
       - tests/*.yaml
 
 jobs:

--- a/.github/workflows/build.github.yml
+++ b/.github/workflows/build.github.yml
@@ -9,8 +9,9 @@ on:
       - images/github/BUILD
       - WORKSPACE
       - rules/images.bzl
-      - images/base/*
-      - images/base/**/*
+      - images/base/image_data/**/*
+      - images/base/test_configs/**/*
+      - images/base/BUILD
       - tests/*.yaml
 
 jobs:

--- a/.github/workflows/build.gitlab.yml
+++ b/.github/workflows/build.gitlab.yml
@@ -9,8 +9,9 @@ on:
       - images/gitlab/BUILD
       - WORKSPACE
       - rules/images.bzl
-      - images/base/*
-      - images/base/**/*
+      - images/base/image_data/**/*
+      - images/base/test_configs/**/*
+      - images/base/BUILD
       - tests/*.yaml
 
 jobs:

--- a/.github/workflows/build.hadolint.yml
+++ b/.github/workflows/build.hadolint.yml
@@ -9,8 +9,9 @@ on:
       - images/hadolint/BUILD
       - WORKSPACE
       - rules/images.bzl
-      - images/base/*
-      - images/base/**/*
+      - images/base/image_data/**/*
+      - images/base/test_configs/**/*
+      - images/base/BUILD
       - tests/*.yaml
 
 jobs:

--- a/.github/workflows/build.htmlhint.yml
+++ b/.github/workflows/build.htmlhint.yml
@@ -9,8 +9,9 @@ on:
       - images/htmlhint/BUILD
       - WORKSPACE
       - rules/images.bzl
-      - images/base/*
-      - images/base/**/*
+      - images/base/image_data/**/*
+      - images/base/test_configs/**/*
+      - images/base/BUILD
       - tests/*.yaml
 
 jobs:

--- a/.github/workflows/build.hugo.yml
+++ b/.github/workflows/build.hugo.yml
@@ -9,8 +9,9 @@ on:
       - images/hugo/BUILD
       - WORKSPACE
       - rules/images.bzl
-      - images/base/*
-      - images/base/**/*
+      - images/base/image_data/**/*
+      - images/base/test_configs/**/*
+      - images/base/BUILD
       - tests/*.yaml
 
 jobs:

--- a/.github/workflows/build.luacheck.yml
+++ b/.github/workflows/build.luacheck.yml
@@ -9,8 +9,9 @@ on:
       - images/luacheck/BUILD
       - WORKSPACE
       - rules/images.bzl
-      - images/base/*
-      - images/base/**/*
+      - images/base/image_data/**/*
+      - images/base/test_configs/**/*
+      - images/base/BUILD
       - tests/*.yaml
 
 jobs:

--- a/.github/workflows/build.markdownlint.yml
+++ b/.github/workflows/build.markdownlint.yml
@@ -9,8 +9,9 @@ on:
       - images/markdownlint/BUILD
       - WORKSPACE
       - rules/images.bzl
-      - images/base/*
-      - images/base/**/*
+      - images/base/image_data/**/*
+      - images/base/test_configs/**/*
+      - images/base/BUILD
       - tests/*.yaml
 
 jobs:

--- a/.github/workflows/build.netlify.yml
+++ b/.github/workflows/build.netlify.yml
@@ -9,8 +9,9 @@ on:
       - images/netlify/BUILD
       - WORKSPACE
       - rules/images.bzl
-      - images/base/*
-      - images/base/**/*
+      - images/base/image_data/**/*
+      - images/base/test_configs/**/*
+      - images/base/BUILD
       - tests/*.yaml
 
 jobs:

--- a/.github/workflows/build.pdf2htmlex.yml
+++ b/.github/workflows/build.pdf2htmlex.yml
@@ -7,8 +7,9 @@ on:
       - images/pdf2htmlex/image_data/**/*
       - images/pdf2htmlex/test_configs/**/*
       - images/pdf2htmlex/BUILD
-      - images/base/*
-      - images/base/**/*
+      - images/base/image_data/**/*
+      - images/base/test_configs/**/*
+      - images/base/BUILD
       - tests/*.yaml
 
 jobs:

--- a/.github/workflows/build.pdftools.yml
+++ b/.github/workflows/build.pdftools.yml
@@ -9,8 +9,9 @@ on:
       - images/pdftools/BUILD
       - WORKSPACE
       - rules/images.bzl
-      - images/base/*
-      - images/base/**/*
+      - images/base/image_data/**/*
+      - images/base/test_configs/**/*
+      - images/base/BUILD
       - tests/*.yaml
 
 jobs:

--- a/.github/workflows/build.psscriptanalyzer.yml
+++ b/.github/workflows/build.psscriptanalyzer.yml
@@ -4,13 +4,15 @@ on:
     paths:
       - .github/workflows/build.psscriptanalyzer.yml
       - .github/actions/image-tag/*
+      - images/psscriptanalyzer/image_scripts/**/*
       - images/psscriptanalyzer/image_data/**/*
       - images/psscriptanalyzer/test_configs/**/*
       - images/psscriptanalyzer/BUILD
       - WORKSPACE
       - rules/images.bzl
-      - images/base/*
-      - images/base/**/*
+      - images/base/image_data/**/*
+      - images/base/test_configs/**/*
+      - images/base/BUILD
       - tests/*.yaml
 
 jobs:

--- a/.github/workflows/build.pylint.yml
+++ b/.github/workflows/build.pylint.yml
@@ -9,8 +9,9 @@ on:
       - images/pylint/BUILD
       - WORKSPACE
       - rules/images.bzl
-      - images/base/*
-      - images/base/**/*
+      - images/base/image_data/**/*
+      - images/base/test_configs/**/*
+      - images/base/BUILD
       - tests/*.yaml
 
 jobs:

--- a/.github/workflows/build.rsvg.yml
+++ b/.github/workflows/build.rsvg.yml
@@ -9,8 +9,9 @@ on:
       - images/rsvg/BUILD
       - WORKSPACE
       - rules/images.bzl
-      - images/base/*
-      - images/base/**/*
+      - images/base/image_data/**/*
+      - images/base/test_configs/**/*
+      - images/base/BUILD
       - tests/*.yaml
 
 jobs:

--- a/.github/workflows/build.rubocop.yml
+++ b/.github/workflows/build.rubocop.yml
@@ -9,8 +9,9 @@ on:
       - images/rubocop/BUILD
       - WORKSPACE
       - rules/images.bzl
-      - images/base/*
-      - images/base/**/*
+      - images/base/image_data/**/*
+      - images/base/test_configs/**/*
+      - images/base/BUILD
       - tests/*.yaml
 
 jobs:

--- a/.github/workflows/build.shellcheck.yml
+++ b/.github/workflows/build.shellcheck.yml
@@ -9,8 +9,9 @@ on:
       - images/shellcheck/BUILD
       - WORKSPACE
       - rules/images.bzl
-      - images/base/*
-      - images/base/**/*
+      - images/base/image_data/**/*
+      - images/base/test_configs/**/*
+      - images/base/BUILD
       - tests/*.yaml
 
 jobs:

--- a/.github/workflows/build.stylelint.yml
+++ b/.github/workflows/build.stylelint.yml
@@ -9,8 +9,9 @@ on:
       - images/stylelint/BUILD
       - WORKSPACE
       - rules/images.bzl
-      - images/base/*
-      - images/base/**/*
+      - images/base/image_data/**/*
+      - images/base/test_configs/**/*
+      - images/base/BUILD
       - tests/*.yaml
 
 jobs:

--- a/.github/workflows/build.surge.yml
+++ b/.github/workflows/build.surge.yml
@@ -9,8 +9,9 @@ on:
       - images/surge/BUILD
       - WORKSPACE
       - rules/images.bzl
-      - images/base/*
-      - images/base/**/*
+      - images/base/image_data/**/*
+      - images/base/test_configs/**/*
+      - images/base/BUILD
       - tests/*.yaml
 
 jobs:

--- a/.github/workflows/build.svgtools.yml
+++ b/.github/workflows/build.svgtools.yml
@@ -9,8 +9,9 @@ on:
       - images/svgtools/BUILD
       - WORKSPACE
       - rules/images.bzl
-      - images/base/*
-      - images/base/**/*
+      - images/base/image_data/**/*
+      - images/base/test_configs/**/*
+      - images/base/BUILD
       - tests/*.yaml
 
 jobs:

--- a/.github/workflows/build.tflint.yml
+++ b/.github/workflows/build.tflint.yml
@@ -9,8 +9,9 @@ on:
       - images/tflint/BUILD
       - WORKSPACE
       - rules/images.bzl
-      - images/base/*
-      - images/base/**/*
+      - images/base/image_data/**/*
+      - images/base/test_configs/**/*
+      - images/base/BUILD
       - tests/*.yaml
 
 jobs:

--- a/.github/workflows/build.wkhtmltopdf.yml
+++ b/.github/workflows/build.wkhtmltopdf.yml
@@ -9,8 +9,9 @@ on:
       - images/wkhtmltopdf/BUILD
       - WORKSPACE
       - rules/images.bzl
-      - images/base/*
-      - images/base/**/*
+      - images/base/image_data/**/*
+      - images/base/test_configs/**/*
+      - images/base/BUILD
       - tests/*.yaml
 
 jobs:

--- a/images/awscli/README.md
+++ b/images/awscli/README.md
@@ -1,71 +1,48 @@
-# Docker image for AWS CLI
+# cardboardci/awscli
+
+cardboardci/awscli is a Docker image built with continuous integration builds in mind. Each tag contains an AWSCLI version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
 
 The AWS Command Line Interface (CLI) is a unified tool to manage your AWS services. With just one tool to download and configure, you can control multiple AWS services from the command line and automate them through scripts.
 
-You can see the cli reference [here](https://docs.aws.amazon.com/cli/latest/reference/).
+## Getting Started
 
-## Usage
+This image can be used with the docker type for different types of continuous integration platforms. For example:
 
-You can run awscli to manage your AWS services.
-
-```bash
-aws iam list-users
-aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
-aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              uses: docker://ghcr.io/cardboardci/awscli:edge
+              with:
+                  args: "aws --version"
 ```
 
 ### Pull latest image
 
+The edge or latest version of the image is available with the tag `edge`. This isn't intended to long term use, but for working with the latest version of the image. To pull the latest image, run the following:
+
 ```bash
-docker pull cardboardci/awscli
+docker pull ghcr.io/cardboardci/awscli:edge
 ```
 
 ### Test interactively
 
+Sometimes it can be useful to run the image in an interactive shell for experimentation. To shell into an image, run the following:
+
 ```bash
-docker run -it cardboardci/awscli /bin/bash
+docker run -it ghcr.io/cardboardci/awscli:edge /bin/bash
 ```
 
 ### Run basic AWS command
 
-```bash
-docker run -it -v "$(pwd)":/workspace cardboardci/awscli aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Run AWS CLI with custom profile
+To run a single command from the context of the docker image, run the following:
 
 ```bash
-docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/awscli aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Continuous Integration Services
-
-For each of the following services, you can see an example of this image in that environment:
-
-* [CircleCI](usages/circleci)
-* [GitHub Actions](usages/github)
-* [GitLabCI](usages/gitlabci)
-* [JenkinsFile](usages/jenkins)
-* [TravisCI](usages/travisci)
-* [Codeship](usages/codeship)
-
-## Tagging Strategy
-
-Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
-
-* `latest`: The most-recently released version of an image. (`cardboardci/awscli:latest`)
-* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/awscli:1.0.0`)
-* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
-
-We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
-
-```bash
-docker pull cardboardci/awscli:latest
-docker inspect --format='{{index .RepoDigests 0}}' cardboardci/awscli:latest
+docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/awscli:edge aws --version
 ```
 
 ## Fundamentals
 
-All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
-
-By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.
+All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.

--- a/images/awscli/README.md
+++ b/images/awscli/README.md
@@ -1,6 +1,6 @@
 # cardboardci/awscli
 
-cardboardci/awscli is a Docker image built with continuous integration builds in mind. Each tag contains an AWSCLI version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
+cardboardci/awscli is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment. This includes `jq`, `curl`, `bash` and utilities fpr interacting with Amazon Web Services (AWS).
 
 The AWS Command Line Interface (CLI) is a unified tool to manage your AWS services. With just one tool to download and configure, you can control multiple AWS services from the command line and automate them through scripts.
 
@@ -35,7 +35,7 @@ Sometimes it can be useful to run the image in an interactive shell for experime
 docker run -it ghcr.io/cardboardci/awscli:edge /bin/bash
 ```
 
-### Run basic AWS command
+### Run a basic command
 
 To run a single command from the context of the docker image, run the following:
 

--- a/images/base/README.md
+++ b/images/base/README.md
@@ -1,8 +1,8 @@
 # cardboardci/base
 
-cardboardci/base is a Docker image built with continuous integration builds in mind. Each tag contains an AWSCLI version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
+cardboardci/base is a Docker image built with continuous integration builds in mind. This image serves as a base image for all CardboardCI images. The image is intended to supply all common dependencies for continuous integration images.
 
-The AWS Command Line Interface (CLI) is a unified tool to manage your AWS services. With just one tool to download and configure, you can control multiple AWS services from the command line and automate them through scripts.
+This image should be used as a base image for all CardboardCI images to avoid unique image configurations that do not work as expected.
 
 ## Getting Started
 
@@ -35,14 +35,10 @@ Sometimes it can be useful to run the image in an interactive shell for experime
 docker run -it ghcr.io/cardboardci/base:edge /bin/bash
 ```
 
-### Run basic AWS command
+### Run a basic command
 
 To run a single command from the context of the docker image, run the following:
 
 ```bash
 docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/base:edge aws --version
 ```
-
-## Fundamentals
-
-All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.

--- a/images/base/README.md
+++ b/images/base/README.md
@@ -1,71 +1,48 @@
-# Docker image for AWS CLI
+# cardboardci/base
+
+cardboardci/base is a Docker image built with continuous integration builds in mind. Each tag contains an AWSCLI version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
 
 The AWS Command Line Interface (CLI) is a unified tool to manage your AWS services. With just one tool to download and configure, you can control multiple AWS services from the command line and automate them through scripts.
 
-You can see the cli reference [here](https://docs.aws.amazon.com/cli/latest/reference/).
+## Getting Started
 
-## Usage
+This image can be used with the docker type for different types of continuous integration platforms. For example:
 
-You can run awscli to manage your AWS services.
-
-```bash
-aws iam list-users
-aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
-aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              uses: docker://ghcr.io/cardboardci/base:edge
+              with:
+                  args: "echo hello"
 ```
 
 ### Pull latest image
 
+The edge or latest version of the image is available with the tag `edge`. This isn't intended to long term use, but for working with the latest version of the image. To pull the latest image, run the following:
+
 ```bash
-docker pull cardboardci/awscli
+docker pull ghcr.io/cardboardci/base:edge
 ```
 
 ### Test interactively
 
+Sometimes it can be useful to run the image in an interactive shell for experimentation. To shell into an image, run the following:
+
 ```bash
-docker run -it cardboardci/awscli /bin/bash
+docker run -it ghcr.io/cardboardci/base:edge /bin/bash
 ```
 
 ### Run basic AWS command
 
-```bash
-docker run -it -v "$(pwd)":/workspace cardboardci/awscli aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Run AWS CLI with custom profile
+To run a single command from the context of the docker image, run the following:
 
 ```bash
-docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/awscli aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Continuous Integration Services
-
-For each of the following services, you can see an example of this image in that environment:
-
-* [CircleCI](usages/circleci)
-* [GitHub Actions](usages/github)
-* [GitLabCI](usages/gitlabci)
-* [JenkinsFile](usages/jenkins)
-* [TravisCI](usages/travisci)
-* [Codeship](usages/codeship)
-
-## Tagging Strategy
-
-Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
-
-* `latest`: The most-recently released version of an image. (`cardboardci/awscli:latest`)
-* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/awscli:1.0.0`)
-* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
-
-We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
-
-```bash
-docker pull cardboardci/awscli:latest
-docker inspect --format='{{index .RepoDigests 0}}' cardboardci/awscli:latest
+docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/base:edge aws --version
 ```
 
 ## Fundamentals
 
-All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
-
-By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.
+All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.

--- a/images/bats/README.md
+++ b/images/bats/README.md
@@ -1,4 +1,6 @@
-# Docker image for Bats (Bash Automated Testing System)
+# cardboardci/bats
+
+cardboardci/bats is a Docker image built with continuous integration builds in mind. Each tag contains an Bats version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
 
 Bats is a TAP-compliant testing framework for Bash. It provides a simple way to verify that the UNIX programs you write behave as expected.
 
@@ -20,68 +22,45 @@ A Bats test file is a Bash script with special syntax for defining test cases. U
 
 You can see the source repository [here](https://github.com/sstephenson/bats/).
 
-## Usage
+## Getting Started
 
-You can run awscli to manage your AWS services.
+This image can be used with the docker type for different types of continuous integration platforms. For example:
 
-```bash
-aws iam list-users
-aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
-aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              uses: docker://ghcr.io/cardboardci/bats:edge
+              with:
+                  args: "bats --version"
 ```
 
 ### Pull latest image
 
+The edge or latest version of the image is available with the tag `edge`. This isn't intended to long term use, but for working with the latest version of the image. To pull the latest image, run the following:
+
 ```bash
-docker pull cardboardci/awscli
+docker pull ghcr.io/cardboardci/bats:edge
 ```
 
 ### Test interactively
 
+Sometimes it can be useful to run the image in an interactive shell for experimentation. To shell into an image, run the following:
+
 ```bash
-docker run -it cardboardci/awscli /bin/bash
+docker run -it ghcr.io/cardboardci/bats:edge /bin/bash
 ```
 
 ### Run basic AWS command
 
-```bash
-docker run -it -v "$(pwd)":/workspace cardboardci/awscli aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Run AWS CLI with custom profile
+To run a single command from the context of the docker image, run the following:
 
 ```bash
-docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/awscli aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Continuous Integration Services
-
-For each of the following services, you can see an example of this image in that environment:
-
-* [CircleCI](usages/circleci)
-* [GitHub Actions](usages/github)
-* [GitLabCI](usages/gitlabci)
-* [JenkinsFile](usages/jenkins)
-* [TravisCI](usages/travisci)
-* [Codeship](usages/codeship)
-
-## Tagging Strategy
-
-Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
-
-* `latest`: The most-recently released version of an image. (`cardboardci/awscli:latest`)
-* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/awscli:1.0.0`)
-* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
-
-We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
-
-```bash
-docker pull cardboardci/awscli:latest
-docker inspect --format='{{index .RepoDigests 0}}' cardboardci/awscli:latest
+docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/bats:edge aws --version
 ```
 
 ## Fundamentals
 
-All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
-
-By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.
+All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.

--- a/images/bats/README.md
+++ b/images/bats/README.md
@@ -1,6 +1,6 @@
 # cardboardci/bats
 
-cardboardci/bats is a Docker image built with continuous integration builds in mind. Each tag contains an Bats version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
+cardboardci/bats is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment. This includes `jq`, `curl`, `bash` and utilities for orchestrating Bash testing.
 
 Bats is a TAP-compliant testing framework for Bash. It provides a simple way to verify that the UNIX programs you write behave as expected.
 
@@ -53,7 +53,7 @@ Sometimes it can be useful to run the image in an interactive shell for experime
 docker run -it ghcr.io/cardboardci/bats:edge /bin/bash
 ```
 
-### Run basic AWS command
+### Run a basic command
 
 To run a single command from the context of the docker image, run the following:
 

--- a/images/cppcheck/README.md
+++ b/images/cppcheck/README.md
@@ -1,6 +1,6 @@
 # cardboardci/cppcheck
 
-cardboardci/cppcheck is a Docker image built with continuous integration builds in mind. Each tag contains an Cppcheck version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
+cardboardci/cppcheck is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment. This includes `jq`, `curl`, `bash` and utilities for static analysis of C++.
 
 Cppcheck is an analysis tool for C/C++ code. It provides unique code analysis
 to detect bugs and focuses on detecting undefined behaviour and dangerous
@@ -40,7 +40,7 @@ Sometimes it can be useful to run the image in an interactive shell for experime
 docker run -it ghcr.io/cardboardci/cppcheck:edge /bin/bash
 ```
 
-### Run basic AWS command
+### Run a basic command
 
 To run a single command from the context of the docker image, run the following:
 

--- a/images/cppcheck/README.md
+++ b/images/cppcheck/README.md
@@ -1,4 +1,6 @@
-# Docker image for CppCheck
+# cardboardci/cppcheck
+
+cardboardci/cppcheck is a Docker image built with continuous integration builds in mind. Each tag contains an Cppcheck version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
 
 Cppcheck is an analysis tool for C/C++ code. It provides unique code analysis
 to detect bugs and focuses on detecting undefined behaviour and dangerous
@@ -7,68 +9,45 @@ very few false positives).
 
 You can see the source repository [here](https://github.com/danmar/cppcheck).
 
-## Usage
+## Getting Started
 
-You can run awscli to manage your AWS services.
+This image can be used with the docker type for different types of continuous integration platforms. For example:
 
-```bash
-aws iam list-users
-aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
-aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              uses: docker://ghcr.io/cardboardci/cppcheck:edge
+              with:
+                  args: "cppcheck --version"
 ```
 
 ### Pull latest image
 
+The edge or latest version of the image is available with the tag `edge`. This isn't intended to long term use, but for working with the latest version of the image. To pull the latest image, run the following:
+
 ```bash
-docker pull cardboardci/awscli
+docker pull ghcr.io/cardboardci/cppcheck:edge
 ```
 
 ### Test interactively
 
+Sometimes it can be useful to run the image in an interactive shell for experimentation. To shell into an image, run the following:
+
 ```bash
-docker run -it cardboardci/awscli /bin/bash
+docker run -it ghcr.io/cardboardci/cppcheck:edge /bin/bash
 ```
 
 ### Run basic AWS command
 
-```bash
-docker run -it -v "$(pwd)":/workspace cardboardci/awscli aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Run AWS CLI with custom profile
+To run a single command from the context of the docker image, run the following:
 
 ```bash
-docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/awscli aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Continuous Integration Services
-
-For each of the following services, you can see an example of this image in that environment:
-
-* [CircleCI](usages/circleci)
-* [GitHub Actions](usages/github)
-* [GitLabCI](usages/gitlabci)
-* [JenkinsFile](usages/jenkins)
-* [TravisCI](usages/travisci)
-* [Codeship](usages/codeship)
-
-## Tagging Strategy
-
-Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
-
-* `latest`: The most-recently released version of an image. (`cardboardci/awscli:latest`)
-* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/awscli:1.0.0`)
-* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
-
-We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
-
-```bash
-docker pull cardboardci/awscli:latest
-docker inspect --format='{{index .RepoDigests 0}}' cardboardci/awscli:latest
+docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/cppcheck:edge aws --version
 ```
 
 ## Fundamentals
 
-All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
-
-By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.
+All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.

--- a/images/dbxcli/README.md
+++ b/images/dbxcli/README.md
@@ -1,77 +1,56 @@
-# Docker image for AWS CLI
+# cardboardci/dbxcli
+
+cardboardci/dbxcli is a Docker image built with continuous integration builds in mind. Each tag contains an DropboxCLI version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
 
 A command line client for Dropbox built using the Go SDK
 
-* Supports basic file operations like ls, cp, mkdir, mv (via the Files API)
-* Supports search
-* Supports file revisions and file restore
-* Chunked uploads for large files, paginated listing for large directories
-* Supports a growing set of Team operations
+-   Supports basic file operations like ls, cp, mkdir, mv (via the Files API)
+-   Supports search
+-   Supports file revisions and file restore
+-   Chunked uploads for large files, paginated listing for large directories
+-   Supports a growing set of Team operations
 
 You can see the source repository [here](https://github.com/dropbox/dbxcli).
 
-## Usage
+## Getting Started
 
-You can run awscli to manage your AWS services.
+This image can be used with the docker type for different types of continuous integration platforms. For example:
 
-```bash
-aws iam list-users
-aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
-aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              uses: docker://ghcr.io/cardboardci/dbxcli:edge
+              with:
+                  args: "dbxcli --version"
 ```
 
 ### Pull latest image
 
+The edge or latest version of the image is available with the tag `edge`. This isn't intended to long term use, but for working with the latest version of the image. To pull the latest image, run the following:
+
 ```bash
-docker pull cardboardci/awscli
+docker pull ghcr.io/cardboardci/dbxcli:edge
 ```
 
 ### Test interactively
 
+Sometimes it can be useful to run the image in an interactive shell for experimentation. To shell into an image, run the following:
+
 ```bash
-docker run -it cardboardci/awscli /bin/bash
+docker run -it ghcr.io/cardboardci/dbxcli:edge /bin/bash
 ```
 
 ### Run basic AWS command
 
-```bash
-docker run -it -v "$(pwd)":/workspace cardboardci/awscli aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Run AWS CLI with custom profile
+To run a single command from the context of the docker image, run the following:
 
 ```bash
-docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/awscli aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Continuous Integration Services
-
-For each of the following services, you can see an example of this image in that environment:
-
-* [CircleCI](usages/circleci)
-* [GitHub Actions](usages/github)
-* [GitLabCI](usages/gitlabci)
-* [JenkinsFile](usages/jenkins)
-* [TravisCI](usages/travisci)
-* [Codeship](usages/codeship)
-
-## Tagging Strategy
-
-Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
-
-* `latest`: The most-recently released version of an image. (`cardboardci/awscli:latest`)
-* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/awscli:1.0.0`)
-* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
-
-We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
-
-```bash
-docker pull cardboardci/awscli:latest
-docker inspect --format='{{index .RepoDigests 0}}' cardboardci/awscli:latest
+docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/dbxcli:edge aws --version
 ```
 
 ## Fundamentals
 
-All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
-
-By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.
+All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.

--- a/images/dbxcli/README.md
+++ b/images/dbxcli/README.md
@@ -1,6 +1,6 @@
 # cardboardci/dbxcli
 
-cardboardci/dbxcli is a Docker image built with continuous integration builds in mind. Each tag contains an DropboxCLI version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
+cardboardci/dbxcli is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment. This includes `jq`, `curl`, `bash` and utilities for interfacing with Dropbox.
 
 A command line client for Dropbox built using the Go SDK
 
@@ -43,7 +43,7 @@ Sometimes it can be useful to run the image in an interactive shell for experime
 docker run -it ghcr.io/cardboardci/dbxcli:edge /bin/bash
 ```
 
-### Run basic AWS command
+### Run a basic command
 
 To run a single command from the context of the docker image, run the following:
 

--- a/images/ecr/README.md
+++ b/images/ecr/README.md
@@ -1,6 +1,6 @@
 # cardboardci/ecr
 
-cardboardci/ecr is a Docker image built with continuous integration builds in mind. Each tag contains an AWSCLI version and any docker binaries and tools that are required for builds to complete successfully in a continuous integration environment.
+cardboardci/ecr is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment. This includes `jq`, `curl`, `bash` and utilities for pushing docker images to AWS Elastic Container Registry (ECR).
 
 The AWS Command Line Interface (CLI) is a unified tool to manage your AWS services. With just one tool to download and configure, you can control multiple AWS services from the command line and automate them through scripts.
 
@@ -35,7 +35,7 @@ Sometimes it can be useful to run the image in an interactive shell for experime
 docker run -it ghcr.io/cardboardci/ecr:edge /bin/bash
 ```
 
-### Run basic AWS command
+### Run a basic command
 
 To run a single command from the context of the docker image, run the following:
 

--- a/images/ecr/README.md
+++ b/images/ecr/README.md
@@ -1,71 +1,48 @@
-# Docker image for AWS CLI & Docker
+# cardboardci/ecr
 
-The AWS Command Line Interface (CLI) is a unified tool to manage your AWS services. With just one tool to download and configure, you can control multiple AWS services from the command line and automate them through scripts. This container includes docker, allowing deployments to Amazon Elastic Container Registry (ECR), a fully-managed Docker container registry.
+cardboardci/ecr is a Docker image built with continuous integration builds in mind. Each tag contains an AWSCLI version and any docker binaries and tools that are required for builds to complete successfully in a continuous integration environment.
 
-You can see the cli reference [here](https://docs.aws.amazon.com/cli/latest/reference/ecr/index.html).
+The AWS Command Line Interface (CLI) is a unified tool to manage your AWS services. With just one tool to download and configure, you can control multiple AWS services from the command line and automate them through scripts.
 
-## Usage
+## Getting Started
 
-You can run awscli to manage your AWS services.
+This image can be used with the docker type for different types of continuous integration platforms. For example:
 
-```bash
-aws iam list-users
-aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
-aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              uses: docker://ghcr.io/cardboardci/ecr:edge
+              with:
+                  args: "aws --version"
 ```
 
 ### Pull latest image
 
+The edge or latest version of the image is available with the tag `edge`. This isn't intended to long term use, but for working with the latest version of the image. To pull the latest image, run the following:
+
 ```bash
-docker pull cardboardci/awscli
+docker pull ghcr.io/cardboardci/ecr:edge
 ```
 
 ### Test interactively
 
+Sometimes it can be useful to run the image in an interactive shell for experimentation. To shell into an image, run the following:
+
 ```bash
-docker run -it cardboardci/awscli /bin/bash
+docker run -it ghcr.io/cardboardci/ecr:edge /bin/bash
 ```
 
 ### Run basic AWS command
 
-```bash
-docker run -it -v "$(pwd)":/workspace cardboardci/awscli aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Run AWS CLI with custom profile
+To run a single command from the context of the docker image, run the following:
 
 ```bash
-docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/awscli aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Continuous Integration Services
-
-For each of the following services, you can see an example of this image in that environment:
-
-* [CircleCI](usages/circleci)
-* [GitHub Actions](usages/github)
-* [GitLabCI](usages/gitlabci)
-* [JenkinsFile](usages/jenkins)
-* [TravisCI](usages/travisci)
-* [Codeship](usages/codeship)
-
-## Tagging Strategy
-
-Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
-
-* `latest`: The most-recently released version of an image. (`cardboardci/awscli:latest`)
-* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/awscli:1.0.0`)
-* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
-
-We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
-
-```bash
-docker pull cardboardci/awscli:latest
-docker inspect --format='{{index .RepoDigests 0}}' cardboardci/awscli:latest
+docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/ecr:edge aws --version
 ```
 
 ## Fundamentals
 
-All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
-
-By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.
+All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.

--- a/images/github/README.md
+++ b/images/github/README.md
@@ -1,6 +1,6 @@
 # cardboardci/github
 
-cardboardci/github is a Docker image built with continuous integration builds in mind. Each tag contains an `gh` version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
+cardboardci/github is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment. This includes `jq`, `curl`, `bash` and utilities for working with GitHub.
 
 gh is GitHub on the command line. It brings pull requests, issues, and other GitHub concepts to the terminal next to where you are already working with git and your code.
 
@@ -35,7 +35,7 @@ Sometimes it can be useful to run the image in an interactive shell for experime
 docker run -it ghcr.io/cardboardci/github:edge /bin/bash
 ```
 
-### Run basic AWS command
+### Run a basic command
 
 To run a single command from the context of the docker image, run the following:
 

--- a/images/github/README.md
+++ b/images/github/README.md
@@ -1,71 +1,48 @@
-# Docker image for GitHubCLI
+# cardboardci/github
 
-`hub` is an extension to command-line git that helps you do everyday GitHub tasks without ever leaving the terminal. `hub` can be safely aliased as git so you can type `$ git <command>`in the shell and get all the usual hub features.
+cardboardci/github is a Docker image built with continuous integration builds in mind. Each tag contains an `gh` version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
 
-You can see the source repository [here](https://github.com/dropbox/dbxcli).
+gh is GitHub on the command line. It brings pull requests, issues, and other GitHub concepts to the terminal next to where you are already working with git and your code.
 
-## Usage
+## Getting Started
 
-You can run awscli to manage your AWS services.
+This image can be used with the docker type for different types of continuous integration platforms. For example:
 
-```bash
-aws iam list-users
-aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
-aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              uses: docker://ghcr.io/cardboardci/github:edge
+              with:
+                  args: "gh --version"
 ```
 
 ### Pull latest image
 
+The edge or latest version of the image is available with the tag `edge`. This isn't intended to long term use, but for working with the latest version of the image. To pull the latest image, run the following:
+
 ```bash
-docker pull cardboardci/awscli
+docker pull ghcr.io/cardboardci/github:edge
 ```
 
 ### Test interactively
 
+Sometimes it can be useful to run the image in an interactive shell for experimentation. To shell into an image, run the following:
+
 ```bash
-docker run -it cardboardci/awscli /bin/bash
+docker run -it ghcr.io/cardboardci/github:edge /bin/bash
 ```
 
 ### Run basic AWS command
 
-```bash
-docker run -it -v "$(pwd)":/workspace cardboardci/awscli aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Run AWS CLI with custom profile
+To run a single command from the context of the docker image, run the following:
 
 ```bash
-docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/awscli aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Continuous Integration Services
-
-For each of the following services, you can see an example of this image in that environment:
-
-* [CircleCI](usages/circleci)
-* [GitHub Actions](usages/github)
-* [GitLabCI](usages/gitlabci)
-* [JenkinsFile](usages/jenkins)
-* [TravisCI](usages/travisci)
-* [Codeship](usages/codeship)
-
-## Tagging Strategy
-
-Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
-
-* `latest`: The most-recently released version of an image. (`cardboardci/awscli:latest`)
-* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/awscli:1.0.0`)
-* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
-
-We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
-
-```bash
-docker pull cardboardci/awscli:latest
-docker inspect --format='{{index .RepoDigests 0}}' cardboardci/awscli:latest
+docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/github:edge aws --version
 ```
 
 ## Fundamentals
 
-All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
-
-By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.
+All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.

--- a/images/gitlab/README.md
+++ b/images/gitlab/README.md
@@ -1,4 +1,6 @@
-# Docker image for GitLabCLI
+# cardboardci/gitlab
+
+cardboardci/gitlab is a Docker image built with continuous integration builds in mind. Each tag contains an GitLabCLI version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
 
 What is GitLabCLI ?
 
@@ -9,68 +11,45 @@ What is GitLabCLI ?
 
 You can see the source repository [here](https://github.com/nmklotas/GitLabCLI).
 
-## Usage
+## Getting Started
 
-You can run awscli to manage your AWS services.
+This image can be used with the docker type for different types of continuous integration platforms. For example:
 
-```bash
-aws iam list-users
-aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
-aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              uses: docker://ghcr.io/cardboardci/gitlab:edge
+              with:
+                  args: "lab --version"
 ```
 
 ### Pull latest image
 
+The edge or latest version of the image is available with the tag `edge`. This isn't intended to long term use, but for working with the latest version of the image. To pull the latest image, run the following:
+
 ```bash
-docker pull cardboardci/awscli
+docker pull ghcr.io/cardboardci/gitlab:edge
 ```
 
 ### Test interactively
 
+Sometimes it can be useful to run the image in an interactive shell for experimentation. To shell into an image, run the following:
+
 ```bash
-docker run -it cardboardci/awscli /bin/bash
+docker run -it ghcr.io/cardboardci/gitlab:edge /bin/bash
 ```
 
 ### Run basic AWS command
 
-```bash
-docker run -it -v "$(pwd)":/workspace cardboardci/awscli aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Run AWS CLI with custom profile
+To run a single command from the context of the docker image, run the following:
 
 ```bash
-docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/awscli aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Continuous Integration Services
-
-For each of the following services, you can see an example of this image in that environment:
-
-* [CircleCI](usages/circleci)
-* [GitHub Actions](usages/github)
-* [GitLabCI](usages/gitlabci)
-* [JenkinsFile](usages/jenkins)
-* [TravisCI](usages/travisci)
-* [Codeship](usages/codeship)
-
-## Tagging Strategy
-
-Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
-
-* `latest`: The most-recently released version of an image. (`cardboardci/awscli:latest`)
-* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/awscli:1.0.0`)
-* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
-
-We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
-
-```bash
-docker pull cardboardci/awscli:latest
-docker inspect --format='{{index .RepoDigests 0}}' cardboardci/awscli:latest
+docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/gitlab:edge aws --version
 ```
 
 ## Fundamentals
 
-All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
-
-By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.
+All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.

--- a/images/gitlab/README.md
+++ b/images/gitlab/README.md
@@ -1,13 +1,13 @@
 # cardboardci/gitlab
 
-cardboardci/gitlab is a Docker image built with continuous integration builds in mind. Each tag contains an GitLabCLI version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
+cardboardci/gitlab is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment. This includes `jq`, `curl`, `bash` and utilities for interacting with GitLab.
 
 What is GitLabCLI ?
 
-* It's a cross platform GitLab command line tool to quickly & naturally perform frequent tasks on GitLab project.
-* It does not force you to hand craft json or use other unnatural ways (for example ids, concatenating of strings) like other CLI's to interact with GitLab.
-* It does not have any dependencies.
-* It's self contained .NET core application - you don't need to have .NET installed for it to work.
+-   It's a cross platform GitLab command line tool to quickly & naturally perform frequent tasks on GitLab project.
+-   It does not force you to hand craft json or use other unnatural ways (for example ids, concatenating of strings) like other CLI's to interact with GitLab.
+-   It does not have any dependencies.
+-   It's self contained .NET core application - you don't need to have .NET installed for it to work.
 
 You can see the source repository [here](https://github.com/nmklotas/GitLabCLI).
 
@@ -42,7 +42,7 @@ Sometimes it can be useful to run the image in an interactive shell for experime
 docker run -it ghcr.io/cardboardci/gitlab:edge /bin/bash
 ```
 
-### Run basic AWS command
+### Run a basic command
 
 To run a single command from the context of the docker image, run the following:
 

--- a/images/hadolint/README.md
+++ b/images/hadolint/README.md
@@ -1,71 +1,50 @@
-# Docker image for HadoLint
+# cardboardci/hadolint
+
+cardboardci/hadolint is a Docker image built with continuous integration builds in mind. Each tag contains an Hadolint version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
 
 A smarter Dockerfile linter that helps you build best practice Docker images. The linter is parsing the Dockerfile into an AST and performs rules on top of the AST. It is standing on the shoulders of ShellCheck to lint the Bash code inside RUN instructions.
 
 You can see the source repository [here](https://github.com/hadolint/hadolint).
 
-## Usage
+## Getting Started
 
-You can run awscli to manage your AWS services.
+This image can be used with the docker type for different types of continuous integration platforms. For example:
 
-```bash
-aws iam list-users
-aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
-aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              uses: docker://ghcr.io/cardboardci/hadolint:edge
+              with:
+                  args: "hadolint --version"
 ```
 
 ### Pull latest image
 
+The edge or latest version of the image is available with the tag `edge`. This isn't intended to long term use, but for working with the latest version of the image. To pull the latest image, run the following:
+
 ```bash
-docker pull cardboardci/awscli
+docker pull ghcr.io/cardboardci/hadolint:edge
 ```
 
 ### Test interactively
 
+Sometimes it can be useful to run the image in an interactive shell for experimentation. To shell into an image, run the following:
+
 ```bash
-docker run -it cardboardci/awscli /bin/bash
+docker run -it ghcr.io/cardboardci/hadolint:edge /bin/bash
 ```
 
 ### Run basic AWS command
 
-```bash
-docker run -it -v "$(pwd)":/workspace cardboardci/awscli aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Run AWS CLI with custom profile
+To run a single command from the context of the docker image, run the following:
 
 ```bash
-docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/awscli aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Continuous Integration Services
-
-For each of the following services, you can see an example of this image in that environment:
-
-* [CircleCI](usages/circleci)
-* [GitHub Actions](usages/github)
-* [GitLabCI](usages/gitlabci)
-* [JenkinsFile](usages/jenkins)
-* [TravisCI](usages/travisci)
-* [Codeship](usages/codeship)
-
-## Tagging Strategy
-
-Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
-
-* `latest`: The most-recently released version of an image. (`cardboardci/awscli:latest`)
-* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/awscli:1.0.0`)
-* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
-
-We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
-
-```bash
-docker pull cardboardci/awscli:latest
-docker inspect --format='{{index .RepoDigests 0}}' cardboardci/awscli:latest
+docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/hadolint:edge aws --version
 ```
 
 ## Fundamentals
 
-All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
-
-By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.
+All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.

--- a/images/hadolint/README.md
+++ b/images/hadolint/README.md
@@ -1,6 +1,6 @@
 # cardboardci/hadolint
 
-cardboardci/hadolint is a Docker image built with continuous integration builds in mind. Each tag contains an Hadolint version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
+cardboardci/hadolint is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment. This includes `jq`, `curl`, `bash` and utilities for static analysis of Dockerfiles.
 
 A smarter Dockerfile linter that helps you build best practice Docker images. The linter is parsing the Dockerfile into an AST and performs rules on top of the AST. It is standing on the shoulders of ShellCheck to lint the Bash code inside RUN instructions.
 
@@ -37,7 +37,7 @@ Sometimes it can be useful to run the image in an interactive shell for experime
 docker run -it ghcr.io/cardboardci/hadolint:edge /bin/bash
 ```
 
-### Run basic AWS command
+### Run a basic command
 
 To run a single command from the context of the docker image, run the following:
 

--- a/images/htmlhint/README.md
+++ b/images/htmlhint/README.md
@@ -1,8 +1,8 @@
 # cardboardci/htmlhint
 
-cardboardci/htmlhint is a Docker image built with continuous integration builds in mind. Each tag contains an HTMLHint version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
+cardboardci/htmlhint is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment. This includes `jq`, `curl`, `bash` and utilities for static analysis of HTML.
 
-The static code analysis tool you need for your HTML. 
+The static code analysis tool you need for your HTML.
 
 You can see the source repository [here](https://github.com/htmlhint/HTMLHint).
 
@@ -37,7 +37,7 @@ Sometimes it can be useful to run the image in an interactive shell for experime
 docker run -it ghcr.io/cardboardci/htmlhint:edge /bin/bash
 ```
 
-### Run basic AWS command
+### Run a basic command
 
 To run a single command from the context of the docker image, run the following:
 

--- a/images/htmlhint/README.md
+++ b/images/htmlhint/README.md
@@ -1,71 +1,50 @@
-# Docker image for HTMLHint
+# cardboardci/htmlhint
+
+cardboardci/htmlhint is a Docker image built with continuous integration builds in mind. Each tag contains an HTMLHint version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
 
 The static code analysis tool you need for your HTML. 
 
 You can see the source repository [here](https://github.com/htmlhint/HTMLHint).
 
-## Usage
+## Getting Started
 
-You can run awscli to manage your AWS services.
+This image can be used with the docker type for different types of continuous integration platforms. For example:
 
-```bash
-aws iam list-users
-aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
-aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              uses: docker://ghcr.io/cardboardci/htmlhint:edge
+              with:
+                  args: "htmlhint --version"
 ```
 
 ### Pull latest image
 
+The edge or latest version of the image is available with the tag `edge`. This isn't intended to long term use, but for working with the latest version of the image. To pull the latest image, run the following:
+
 ```bash
-docker pull cardboardci/htmlhint
+docker pull ghcr.io/cardboardci/htmlhint:edge
 ```
 
 ### Test interactively
 
+Sometimes it can be useful to run the image in an interactive shell for experimentation. To shell into an image, run the following:
+
 ```bash
-docker run -it cardboardci/htmlhint /bin/bash
+docker run -it ghcr.io/cardboardci/htmlhint:edge /bin/bash
 ```
 
 ### Run basic AWS command
 
-```bash
-docker run -it -v "$(pwd)":/workspace cardboardci/htmlhint aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Run AWS CLI with custom profile
+To run a single command from the context of the docker image, run the following:
 
 ```bash
-docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/htmlhint aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Continuous Integration Services
-
-For each of the following services, you can see an example of this image in that environment:
-
-* [CircleCI](usages/circleci)
-* [GitHub Actions](usages/github)
-* [GitLabCI](usages/gitlabci)
-* [JenkinsFile](usages/jenkins)
-* [TravisCI](usages/travisci)
-* [Codeship](usages/codeship)
-
-## Tagging Strategy
-
-Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
-
-* `latest`: The most-recently released version of an image. (`cardboardci/htmlhint:latest`)
-* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/htmlhint:1.0.0`)
-* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
-
-We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
-
-```bash
-docker pull cardboardci/htmlhint:latest
-docker inspect --format='{{index .RepoDigests 0}}' cardboardci/htmlhint:latest
+docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/htmlhint:edge aws --version
 ```
 
 ## Fundamentals
 
-All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
-
-By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.
+All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.

--- a/images/hugo/README.md
+++ b/images/hugo/README.md
@@ -1,6 +1,6 @@
 # cardboardci/hugo
 
-cardboardci/hugo is a Docker image built with continuous integration builds in mind. Each tag contains an Hugo version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
+cardboardci/hugo is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment. This includes `jq`, `curl`, `bash` and utilities for generating static websites with Hugo.
 
 Hugo is one of the most popular open-source static site generators. With its amazing speed and flexibility, Hugo makes building websites fun again.
 
@@ -37,7 +37,7 @@ Sometimes it can be useful to run the image in an interactive shell for experime
 docker run -it ghcr.io/cardboardci/hugo:edge /bin/bash
 ```
 
-### Run basic AWS command
+### Run a basic command
 
 To run a single command from the context of the docker image, run the following:
 

--- a/images/hugo/README.md
+++ b/images/hugo/README.md
@@ -1,71 +1,50 @@
-# Docker image for Hugo
+# cardboardci/hugo
+
+cardboardci/hugo is a Docker image built with continuous integration builds in mind. Each tag contains an Hugo version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
 
 Hugo is one of the most popular open-source static site generators. With its amazing speed and flexibility, Hugo makes building websites fun again.
 
 You can see the cli reference [here](https://github.com/gohugoio/hugo/).
 
-## Usage
+## Getting Started
 
-You can run awscli to manage your AWS services.
+This image can be used with the docker type for different types of continuous integration platforms. For example:
 
-```bash
-aws iam list-users
-aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
-aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              uses: docker://ghcr.io/cardboardci/hugo:edge
+              with:
+                  args: "hugo --version"
 ```
 
 ### Pull latest image
 
+The edge or latest version of the image is available with the tag `edge`. This isn't intended to long term use, but for working with the latest version of the image. To pull the latest image, run the following:
+
 ```bash
-docker pull cardboardci/hugo
+docker pull ghcr.io/cardboardci/hugo:edge
 ```
 
 ### Test interactively
 
+Sometimes it can be useful to run the image in an interactive shell for experimentation. To shell into an image, run the following:
+
 ```bash
-docker run -it cardboardci/hugo /bin/bash
+docker run -it ghcr.io/cardboardci/hugo:edge /bin/bash
 ```
 
 ### Run basic AWS command
 
-```bash
-docker run -it -v "$(pwd)":/workspace cardboardci/hugo aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Run AWS CLI with custom profile
+To run a single command from the context of the docker image, run the following:
 
 ```bash
-docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/hugo aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Continuous Integration Services
-
-For each of the following services, you can see an example of this image in that environment:
-
-* [CircleCI](usages/circleci)
-* [GitHub Actions](usages/github)
-* [GitLabCI](usages/gitlabci)
-* [JenkinsFile](usages/jenkins)
-* [TravisCI](usages/travisci)
-* [Codeship](usages/codeship)
-
-## Tagging Strategy
-
-Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
-
-* `latest`: The most-recently released version of an image. (`cardboardci/hugo:latest`)
-* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/hugo:1.0.0`)
-* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
-
-We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
-
-```bash
-docker pull cardboardci/hugo:latest
-docker inspect --format='{{index .RepoDigests 0}}' cardboardci/hugo:latest
+docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/hugo:edge aws --version
 ```
 
 ## Fundamentals
 
-All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
-
-By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.
+All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.

--- a/images/luacheck/README.md
+++ b/images/luacheck/README.md
@@ -1,71 +1,50 @@
-# Docker image for LuaCheck
+# cardboardci/luacheck
+
+cardboardci/luacheck is a Docker image built with continuous integration builds in mind. Each tag contains an Luacheck version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
 
 Luacheck is a static analyzer and a linter for Lua. Luacheck detects various issues such as usage of undefined global variables, unused variables and values, accessing uninitialized variables, unreachable code and more. Most aspects of checking are configurable: there are options for defining custom project-related globals, for selecting set of standard globals (version of Lua standard library), for filtering warnings by type and name of related variable, etc. The options can be used on the command line, put into a config or directly into checked files as Lua comments.
 
 You can see the cli reference [here](https://github.com/mpeterv/luacheck).
 
-## Usage
+## Getting Started
 
-You can run awscli to manage your AWS services.
+This image can be used with the docker type for different types of continuous integration platforms. For example:
 
-```bash
-aws iam list-users
-aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
-aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              uses: docker://ghcr.io/cardboardci/luacheck:edge
+              with:
+                  args: "luacheck --version"
 ```
 
 ### Pull latest image
 
+The edge or latest version of the image is available with the tag `edge`. This isn't intended to long term use, but for working with the latest version of the image. To pull the latest image, run the following:
+
 ```bash
-docker pull cardboardci/luacheck
+docker pull ghcr.io/cardboardci/luacheck:edge
 ```
 
 ### Test interactively
 
+Sometimes it can be useful to run the image in an interactive shell for experimentation. To shell into an image, run the following:
+
 ```bash
-docker run -it cardboardci/luacheck /bin/bash
+docker run -it ghcr.io/cardboardci/luacheck:edge /bin/bash
 ```
 
 ### Run basic AWS command
 
-```bash
-docker run -it -v "$(pwd)":/workspace cardboardci/luacheck aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Run AWS CLI with custom profile
+To run a single command from the context of the docker image, run the following:
 
 ```bash
-docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/luacheck aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Continuous Integration Services
-
-For each of the following services, you can see an example of this image in that environment:
-
-* [CircleCI](usages/circleci)
-* [GitHub Actions](usages/github)
-* [GitLabCI](usages/gitlabci)
-* [JenkinsFile](usages/jenkins)
-* [TravisCI](usages/travisci)
-* [Codeship](usages/codeship)
-
-## Tagging Strategy
-
-Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
-
-* `latest`: The most-recently released version of an image. (`cardboardci/luacheck:latest`)
-* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/luacheck:1.0.0`)
-* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
-
-We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
-
-```bash
-docker pull cardboardci/luacheck:latest
-docker inspect --format='{{index .RepoDigests 0}}' cardboardci/luacheck:latest
+docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/luacheck:edge aws --version
 ```
 
 ## Fundamentals
 
-All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
-
-By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.
+All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.

--- a/images/luacheck/README.md
+++ b/images/luacheck/README.md
@@ -1,6 +1,6 @@
 # cardboardci/luacheck
 
-cardboardci/luacheck is a Docker image built with continuous integration builds in mind. Each tag contains an Luacheck version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
+cardboardci/luacheck is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment. This includes `jq`, `curl`, `bash` and utilities for static analysis of Lua.
 
 Luacheck is a static analyzer and a linter for Lua. Luacheck detects various issues such as usage of undefined global variables, unused variables and values, accessing uninitialized variables, unreachable code and more. Most aspects of checking are configurable: there are options for defining custom project-related globals, for selecting set of standard globals (version of Lua standard library), for filtering warnings by type and name of related variable, etc. The options can be used on the command line, put into a config or directly into checked files as Lua comments.
 
@@ -37,7 +37,7 @@ Sometimes it can be useful to run the image in an interactive shell for experime
 docker run -it ghcr.io/cardboardci/luacheck:edge /bin/bash
 ```
 
-### Run basic AWS command
+### Run a basic command
 
 To run a single command from the context of the docker image, run the following:
 

--- a/images/markdownlint/README.md
+++ b/images/markdownlint/README.md
@@ -1,4 +1,6 @@
-# Docker image for MarkdownLint
+# cardboardci/markdownlint
+
+cardboardci/markdownlint is a Docker image built with continuous integration builds in mind. Each tag contains an markdownlint version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
 
 A tool to check markdown files and flag style issues. To have markdownlint check your markdown files, simply run mdl with the filenames as a parameter:
 
@@ -14,68 +16,45 @@ mdl docs/
 
 You can see the cli reference [here](https://github.com/markdownlint/markdownlint).
 
-## Usage
+## Getting Started
 
-You can run awscli to manage your AWS services.
+This image can be used with the docker type for different types of continuous integration platforms. For example:
 
-```bash
-aws iam list-users
-aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
-aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              uses: docker://ghcr.io/cardboardci/markdownlint:edge
+              with:
+                  args: "markdownlint --version"
 ```
 
 ### Pull latest image
 
+The edge or latest version of the image is available with the tag `edge`. This isn't intended to long term use, but for working with the latest version of the image. To pull the latest image, run the following:
+
 ```bash
-docker pull cardboardci/markdownlint
+docker pull ghcr.io/cardboardci/markdownlint:edge
 ```
 
 ### Test interactively
 
+Sometimes it can be useful to run the image in an interactive shell for experimentation. To shell into an image, run the following:
+
 ```bash
-docker run -it cardboardci/markdownlint /bin/bash
+docker run -it ghcr.io/cardboardci/markdownlint:edge /bin/bash
 ```
 
 ### Run basic AWS command
 
-```bash
-docker run -it -v "$(pwd)":/workspace cardboardci/markdownlint aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Run AWS CLI with custom profile
+To run a single command from the context of the docker image, run the following:
 
 ```bash
-docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/markdownlint aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Continuous Integration Services
-
-For each of the following services, you can see an example of this image in that environment:
-
-* [CircleCI](usages/circleci)
-* [GitHub Actions](usages/github)
-* [GitLabCI](usages/gitlabci)
-* [JenkinsFile](usages/jenkins)
-* [TravisCI](usages/travisci)
-* [Codeship](usages/codeship)
-
-## Tagging Strategy
-
-Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
-
-* `latest`: The most-recently released version of an image. (`cardboardci/markdownlint:latest`)
-* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/markdownlint:1.0.0`)
-* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
-
-We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
-
-```bash
-docker pull cardboardci/markdownlint:latest
-docker inspect --format='{{index .RepoDigests 0}}' cardboardci/markdownlint:latest
+docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/markdownlint:edge aws --version
 ```
 
 ## Fundamentals
 
-All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
-
-By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.
+All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.

--- a/images/markdownlint/README.md
+++ b/images/markdownlint/README.md
@@ -1,6 +1,6 @@
 # cardboardci/markdownlint
 
-cardboardci/markdownlint is a Docker image built with continuous integration builds in mind. Each tag contains an markdownlint version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
+cardboardci/markdownlint is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment. This includes `jq`, `curl`, `bash` and utilities for static analysis of Markdown.
 
 A tool to check markdown files and flag style issues. To have markdownlint check your markdown files, simply run mdl with the filenames as a parameter:
 
@@ -47,7 +47,7 @@ Sometimes it can be useful to run the image in an interactive shell for experime
 docker run -it ghcr.io/cardboardci/markdownlint:edge /bin/bash
 ```
 
-### Run basic AWS command
+### Run a basic command
 
 To run a single command from the context of the docker image, run the following:
 

--- a/images/netlify/README.md
+++ b/images/netlify/README.md
@@ -1,6 +1,6 @@
 # cardboardci/netlify
 
-cardboardci/netlify is a Docker image built with continuous integration builds in mind. Each tag contains an NetlifyCLI version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
+cardboardci/netlify is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment. This includes `jq`, `curl`, `bash` and utilities for deploying to netlify.
 
 The Netlify CLI facilitates the deployment of websites to Netlify, to improve the site building experience.
 
@@ -37,7 +37,7 @@ Sometimes it can be useful to run the image in an interactive shell for experime
 docker run -it ghcr.io/cardboardci/netlify:edge /bin/bash
 ```
 
-### Run basic AWS command
+### Run a basic command
 
 To run a single command from the context of the docker image, run the following:
 

--- a/images/netlify/README.md
+++ b/images/netlify/README.md
@@ -1,71 +1,50 @@
-# Docker image for Netlify
+# cardboardci/netlify
+
+cardboardci/netlify is a Docker image built with continuous integration builds in mind. Each tag contains an NetlifyCLI version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
 
 The Netlify CLI facilitates the deployment of websites to Netlify, to improve the site building experience.
 
 You can see the cli reference [here](https://github.com/netlify/cli).
 
-## Usage
+## Getting Started
 
-You can run awscli to manage your AWS services.
+This image can be used with the docker type for different types of continuous integration platforms. For example:
 
-```bash
-aws iam list-users
-aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
-aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              uses: docker://ghcr.io/cardboardci/netlify:edge
+              with:
+                  args: "netlify --version"
 ```
 
 ### Pull latest image
 
+The edge or latest version of the image is available with the tag `edge`. This isn't intended to long term use, but for working with the latest version of the image. To pull the latest image, run the following:
+
 ```bash
-docker pull cardboardci/netlify
+docker pull ghcr.io/cardboardci/netlify:edge
 ```
 
 ### Test interactively
 
+Sometimes it can be useful to run the image in an interactive shell for experimentation. To shell into an image, run the following:
+
 ```bash
-docker run -it cardboardci/netlify /bin/bash
+docker run -it ghcr.io/cardboardci/netlify:edge /bin/bash
 ```
 
 ### Run basic AWS command
 
-```bash
-docker run -it -v "$(pwd)":/workspace cardboardci/netlify aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Run AWS CLI with custom profile
+To run a single command from the context of the docker image, run the following:
 
 ```bash
-docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/netlify aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Continuous Integration Services
-
-For each of the following services, you can see an example of this image in that environment:
-
-* [CircleCI](usages/circleci)
-* [GitHub Actions](usages/github)
-* [GitLabCI](usages/gitlabci)
-* [JenkinsFile](usages/jenkins)
-* [TravisCI](usages/travisci)
-* [Codeship](usages/codeship)
-
-## Tagging Strategy
-
-Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
-
-* `latest`: The most-recently released version of an image. (`cardboardci/netlify:latest`)
-* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/netlify:1.0.0`)
-* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
-
-We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
-
-```bash
-docker pull cardboardci/netlify:latest
-docker inspect --format='{{index .RepoDigests 0}}' cardboardci/netlify:latest
+docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/netlify:edge aws --version
 ```
 
 ## Fundamentals
 
-All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
-
-By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.
+All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.

--- a/images/pdf2htmlex/README.md
+++ b/images/pdf2htmlex/README.md
@@ -1,4 +1,6 @@
-# Docker image for Pdf2HtmlEX
+# cardboardci/pdf2htmlex
+
+cardboardci/pdf2htmlex is a Docker image built with continuous integration builds in mind. Each tag contains an pdf2htmlEX version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
 
 pdf2htmlEX renders PDF files in HTML, utilizing modern Web technologies. Academic papers with lots of formulas and figures? Magazines with complicated layouts? No problem!
 
@@ -11,68 +13,45 @@ Features:
 
 You can see the cli reference [here](https://github.com/coolwanglu/pdf2htmlEX).
 
-## Usage
+## Getting Started
 
-You can run awscli to manage your AWS services.
+This image can be used with the docker type for different types of continuous integration platforms. For example:
 
-```bash
-aws iam list-users
-aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
-aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              uses: docker://ghcr.io/cardboardci/pdf2htmlex:edge
+              with:
+                  args: "pdf2htmlex --version"
 ```
 
 ### Pull latest image
 
+The edge or latest version of the image is available with the tag `edge`. This isn't intended to long term use, but for working with the latest version of the image. To pull the latest image, run the following:
+
 ```bash
-docker pull cardboardci/pdf2htmlex
+docker pull ghcr.io/cardboardci/pdf2htmlex:edge
 ```
 
 ### Test interactively
 
+Sometimes it can be useful to run the image in an interactive shell for experimentation. To shell into an image, run the following:
+
 ```bash
-docker run -it cardboardci/pdf2htmlex /bin/bash
+docker run -it ghcr.io/cardboardci/pdf2htmlex:edge /bin/bash
 ```
 
 ### Run basic AWS command
 
-```bash
-docker run -it -v "$(pwd)":/workspace cardboardci/pdf2htmlex aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Run AWS CLI with custom profile
+To run a single command from the context of the docker image, run the following:
 
 ```bash
-docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/pdf2htmlex aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Continuous Integration Services
-
-For each of the following services, you can see an example of this image in that environment:
-
-* [CircleCI](usages/circleci)
-* [GitHub Actions](usages/github)
-* [GitLabCI](usages/gitlabci)
-* [JenkinsFile](usages/jenkins)
-* [TravisCI](usages/travisci)
-* [Codeship](usages/codeship)
-
-## Tagging Strategy
-
-Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
-
-* `latest`: The most-recently released version of an image. (`cardboardci/pdf2htmlex:latest`)
-* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/pdf2htmlex:1.0.0`)
-* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
-
-We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
-
-```bash
-docker pull cardboardci/pdf2htmlex:latest
-docker inspect --format='{{index .RepoDigests 0}}' cardboardci/pdf2htmlex:latest
+docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/pdf2htmlex:edge aws --version
 ```
 
 ## Fundamentals
 
-All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
-
-By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.
+All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.

--- a/images/pdf2htmlex/README.md
+++ b/images/pdf2htmlex/README.md
@@ -1,15 +1,15 @@
 # cardboardci/pdf2htmlex
 
-cardboardci/pdf2htmlex is a Docker image built with continuous integration builds in mind. Each tag contains an pdf2htmlEX version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
+cardboardci/pdf2htmlex is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment. This includes `jq`, `curl`, `bash` and utilities for converting PDFs to HTML.
 
 pdf2htmlEX renders PDF files in HTML, utilizing modern Web technologies. Academic papers with lots of formulas and figures? Magazines with complicated layouts? No problem!
 
 Features:
 
-* Native HTML text with precise font and location.
-* Flexible output: all-in-one HTML or on demand page loading (needs JavaScript).
-* Moderate file size, sometimes even smaller than PDF.
-* Supporting links, outlines (bookmarks), printing, SVG background, Type 3 fonts and more.
+-   Native HTML text with precise font and location.
+-   Flexible output: all-in-one HTML or on demand page loading (needs JavaScript).
+-   Moderate file size, sometimes even smaller than PDF.
+-   Supporting links, outlines (bookmarks), printing, SVG background, Type 3 fonts and more.
 
 You can see the cli reference [here](https://github.com/coolwanglu/pdf2htmlEX).
 
@@ -44,7 +44,7 @@ Sometimes it can be useful to run the image in an interactive shell for experime
 docker run -it ghcr.io/cardboardci/pdf2htmlex:edge /bin/bash
 ```
 
-### Run basic AWS command
+### Run a basic command
 
 To run a single command from the context of the docker image, run the following:
 

--- a/images/pdftools/README.md
+++ b/images/pdftools/README.md
@@ -1,6 +1,6 @@
 # cardboardci/pdftools
 
-cardboardci/pdftools is a Docker image built with continuous integration builds in mind. Each tag contains an pdftools version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
+cardboardci/pdftools is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment. This includes `jq`, `curl`, `bash` and utilities for working with PDFs.
 
 Scientific articles are typically locked away in PDF format, a format designed primarily for printing but not so great for searching or indexing. The new pdftools package allows for extracting text and metadata from pdf files in R. From the extracted plain-text one could find articles discussing a particular drug or species name, without having to rely on publishers providing metadata, or pay-walled search engines.
 
@@ -37,7 +37,7 @@ Sometimes it can be useful to run the image in an interactive shell for experime
 docker run -it ghcr.io/cardboardci/pdftools:edge /bin/bash
 ```
 
-### Run basic AWS command
+### Run a basic command
 
 To run a single command from the context of the docker image, run the following:
 

--- a/images/pdftools/README.md
+++ b/images/pdftools/README.md
@@ -1,71 +1,50 @@
-# Docker image for PdfTools
+# cardboardci/pdftools
+
+cardboardci/pdftools is a Docker image built with continuous integration builds in mind. Each tag contains an pdftools version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
 
 Scientific articles are typically locked away in PDF format, a format designed primarily for printing but not so great for searching or indexing. The new pdftools package allows for extracting text and metadata from pdf files in R. From the extracted plain-text one could find articles discussing a particular drug or species name, without having to rely on publishers providing metadata, or pay-walled search engines.
 
 You can see the cli reference [here](https://github.com/ropensci/pdftools).
 
-## Usage
+## Getting Started
 
-You can run awscli to manage your AWS services.
+This image can be used with the docker type for different types of continuous integration platforms. For example:
 
-```bash
-aws iam list-users
-aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
-aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              uses: docker://ghcr.io/cardboardci/pdftools:edge
+              with:
+                  args: "pdftools --version"
 ```
 
 ### Pull latest image
 
+The edge or latest version of the image is available with the tag `edge`. This isn't intended to long term use, but for working with the latest version of the image. To pull the latest image, run the following:
+
 ```bash
-docker pull cardboardci/pdftools
+docker pull ghcr.io/cardboardci/pdftools:edge
 ```
 
 ### Test interactively
 
+Sometimes it can be useful to run the image in an interactive shell for experimentation. To shell into an image, run the following:
+
 ```bash
-docker run -it cardboardci/pdftools /bin/bash
+docker run -it ghcr.io/cardboardci/pdftools:edge /bin/bash
 ```
 
 ### Run basic AWS command
 
-```bash
-docker run -it -v "$(pwd)":/workspace cardboardci/pdftools aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Run AWS CLI with custom profile
+To run a single command from the context of the docker image, run the following:
 
 ```bash
-docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/pdftools aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Continuous Integration Services
-
-For each of the following services, you can see an example of this image in that environment:
-
-* [CircleCI](usages/circleci)
-* [GitHub Actions](usages/github)
-* [GitLabCI](usages/gitlabci)
-* [JenkinsFile](usages/jenkins)
-* [TravisCI](usages/travisci)
-* [Codeship](usages/codeship)
-
-## Tagging Strategy
-
-Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
-
-* `latest`: The most-recently released version of an image. (`cardboardci/pdftools:latest`)
-* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/pdftools:1.0.0`)
-* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
-
-We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
-
-```bash
-docker pull cardboardci/pdftools:latest
-docker inspect --format='{{index .RepoDigests 0}}' cardboardci/pdftools:latest
+docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/pdftools:edge aws --version
 ```
 
 ## Fundamentals
 
-All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
-
-By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.
+All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.

--- a/images/psscriptanalyzer/README.md
+++ b/images/psscriptanalyzer/README.md
@@ -1,6 +1,6 @@
 # cardboardci/psscriptanalyzer
 
-cardboardci/psscriptanalyzer is a Docker image built with continuous integration builds in mind. Each tag contains an PSScriptAnalyzer version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
+cardboardci/psscriptanalyzer is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment. This includes `jq`, `curl`, `bash` and utilities for static analysis of PowerShell.
 
 PSScriptAnalyzer is a static code checker for Windows PowerShell modules and scripts. PSScriptAnalyzer checks the quality of Windows PowerShell code by running a set of rules. The rules are based on PowerShell best practices identified by PowerShell Team and the community. It generates DiagnosticResults (errors and warnings) to inform users about potential code defects and suggests possible solutions for improvements.
 
@@ -37,7 +37,7 @@ Sometimes it can be useful to run the image in an interactive shell for experime
 docker run -it ghcr.io/cardboardci/psscriptanalyzer:edge /bin/bash
 ```
 
-### Run basic AWS command
+### Run a basic command
 
 To run a single command from the context of the docker image, run the following:
 

--- a/images/psscriptanalyzer/README.md
+++ b/images/psscriptanalyzer/README.md
@@ -1,83 +1,50 @@
-# Docker image for PSScriptAnalyzer
+# cardboardci/psscriptanalyzer
+
+cardboardci/psscriptanalyzer is a Docker image built with continuous integration builds in mind. Each tag contains an PSScriptAnalyzer version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
 
 PSScriptAnalyzer is a static code checker for Windows PowerShell modules and scripts. PSScriptAnalyzer checks the quality of Windows PowerShell code by running a set of rules. The rules are based on PowerShell best practices identified by PowerShell Team and the community. It generates DiagnosticResults (errors and warnings) to inform users about potential code defects and suggests possible solutions for improvements.
 
 You can see the cli reference [here](https://github.com/PowerShell/PSScriptAnalyzer).
 
-## Usage
+## Getting Started
 
-You can run awscli to manage your AWS services.
+This image can be used with the docker type for different types of continuous integration platforms. For example:
 
-```bash
-aws iam list-users
-aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
-aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              uses: docker://ghcr.io/cardboardci/psscriptanalyzer:edge
+              with:
+                  args: "PSFormatter"
 ```
 
 ### Pull latest image
 
+The edge or latest version of the image is available with the tag `edge`. This isn't intended to long term use, but for working with the latest version of the image. To pull the latest image, run the following:
+
 ```bash
-docker pull cardboardci/psscriptanalyzer
+docker pull ghcr.io/cardboardci/psscriptanalyzer:edge
 ```
 
 ### Test interactively
 
+Sometimes it can be useful to run the image in an interactive shell for experimentation. To shell into an image, run the following:
+
 ```bash
-docker run -it cardboardci/psscriptanalyzer pwsh
+docker run -it ghcr.io/cardboardci/psscriptanalyzer:edge /bin/bash
 ```
 
-### Test interactively with Bash
+### Run basic AWS command
+
+To run a single command from the context of the docker image, run the following:
 
 ```bash
-docker run -it cardboardci/psscriptanalyzer bash
-```
-
-### Emit version table
-
-```bash
-docker run -it cardboardci/psscriptanalyzer pwsh -Command '$PSVersionTable'
-```
-
-### Emit versions of installed modules
-
-```bash
-docker run -it cardboardci/psscriptanalyzer pwsh -Command 'Get-InstalledModule'
-```
-
-### Run format invocation
-
-```bash
-docker run -it -v "$(pwd)":/workspace cardboardci/psscriptanalyzer pwsh -Command 'Invoke-Formatter -ScriptDefinition (Get-Content -Path 'File.ps1' -Raw)'
-```
-
-### Continuous Integration Services
-
-For each of the following services, you can see an example of this image in that environment:
-
-* [CircleCI](usages/circleci)
-* [GitHub Actions](usages/github)
-* [GitLabCI](usages/gitlabci)
-* [JenkinsFile](usages/jenkins)
-* [TravisCI](usages/travisci)
-* [Codeship](usages/codeship)
-
-## Tagging Strategy
-
-Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
-
-* `latest`: The most-recently released version of an image. (`cardboardci/psscriptanalyzer:latest`)
-* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/psscriptanalyzer:1.0.0`)
-* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
-
-We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
-
-```bash
-docker pull cardboardci/psscriptanalyzer:latest
-docker inspect --format='{{index .RepoDigests 0}}' cardboardci/psscriptanalyzer:latest
+docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/psscriptanalyzer:edge aws --version
 ```
 
 ## Fundamentals
 
-All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
-
-By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.
+All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.

--- a/images/pylint/README.md
+++ b/images/pylint/README.md
@@ -1,4 +1,6 @@
-# Docker image for PyLint
+# cardboardci/pylint
+
+cardboardci/pylint is a Docker image built with continuous integration builds in mind. Each tag contains an Pylint version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
 
 Pylint is a Python static code analysis tool which looks for programming errors, helps enforcing a coding standard, sniffs for code smells and offers simple refactoring suggestions.
 
@@ -6,68 +8,45 @@ It's highly configurable, having special pragmas to control its errors and warni
 
 You can see the cli reference [here](https://github.com/PyCQA/pylint/).
 
-## Usage
+## Getting Started
 
-You can run awscli to manage your AWS services.
+This image can be used with the docker type for different types of continuous integration platforms. For example:
 
-```bash
-aws iam list-users
-aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
-aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              uses: docker://ghcr.io/cardboardci/pylint:edge
+              with:
+                  args: "pylint --version"
 ```
 
 ### Pull latest image
 
+The edge or latest version of the image is available with the tag `edge`. This isn't intended to long term use, but for working with the latest version of the image. To pull the latest image, run the following:
+
 ```bash
-docker pull cardboardci/pylint
+docker pull ghcr.io/cardboardci/pylint:edge
 ```
 
 ### Test interactively
 
+Sometimes it can be useful to run the image in an interactive shell for experimentation. To shell into an image, run the following:
+
 ```bash
-docker run -it cardboardci/pylint /bin/bash
+docker run -it ghcr.io/cardboardci/pylint:edge /bin/bash
 ```
 
 ### Run basic AWS command
 
-```bash
-docker run -it -v "$(pwd)":/workspace cardboardci/pylint aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Run AWS CLI with custom profile
+To run a single command from the context of the docker image, run the following:
 
 ```bash
-docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/pylint aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Continuous Integration Services
-
-For each of the following services, you can see an example of this image in that environment:
-
-* [CircleCI](usages/circleci)
-* [GitHub Actions](usages/github)
-* [GitLabCI](usages/gitlabci)
-* [JenkinsFile](usages/jenkins)
-* [TravisCI](usages/travisci)
-* [Codeship](usages/codeship)
-
-## Tagging Strategy
-
-Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
-
-* `latest`: The most-recently released version of an image. (`cardboardci/pylint:latest`)
-* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/pylint:1.0.0`)
-* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
-
-We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
-
-```bash
-docker pull cardboardci/pylint:latest
-docker inspect --format='{{index .RepoDigests 0}}' cardboardci/pylint:latest
+docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/pylint:edge aws --version
 ```
 
 ## Fundamentals
 
-All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
-
-By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.
+All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.

--- a/images/pylint/README.md
+++ b/images/pylint/README.md
@@ -1,6 +1,6 @@
 # cardboardci/pylint
 
-cardboardci/pylint is a Docker image built with continuous integration builds in mind. Each tag contains an Pylint version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
+cardboardci/pylint is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment. This includes `jq`, `curl`, `bash` and utilities for linting of Python.
 
 Pylint is a Python static code analysis tool which looks for programming errors, helps enforcing a coding standard, sniffs for code smells and offers simple refactoring suggestions.
 
@@ -39,7 +39,7 @@ Sometimes it can be useful to run the image in an interactive shell for experime
 docker run -it ghcr.io/cardboardci/pylint:edge /bin/bash
 ```
 
-### Run basic AWS command
+### Run a basic command
 
 To run a single command from the context of the docker image, run the following:
 

--- a/images/rsvg/README.md
+++ b/images/rsvg/README.md
@@ -1,6 +1,6 @@
 # cardboardci/rsvg
 
-cardboardci/rsvg is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
+cardboardci/rsvg is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment. This includes `jq`, `curl`, `bash` and utilities for working with Scalable Vector Graphics (SVG).
 
 A utility to render Scalable Vector Graphics (SVG), associated with the GNOME Project. It renders SVG files to Cairo surfaces. Cairo is the 2D, antialiased drawing library that GNOME uses to draw things to the screen or to generate output for printing.
 
@@ -37,7 +37,7 @@ Sometimes it can be useful to run the image in an interactive shell for experime
 docker run -it ghcr.io/cardboardci/rsvg:edge /bin/bash
 ```
 
-### Run basic AWS command
+### Run a basic command
 
 To run a single command from the context of the docker image, run the following:
 

--- a/images/rsvg/README.md
+++ b/images/rsvg/README.md
@@ -1,71 +1,50 @@
-# Docker image for Render SVGs
+# cardboardci/rsvg
+
+cardboardci/rsvg is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
 
 A utility to render Scalable Vector Graphics (SVG), associated with the GNOME Project. It renders SVG files to Cairo surfaces. Cairo is the 2D, antialiased drawing library that GNOME uses to draw things to the screen or to generate output for printing.
 
 You can see the cli reference [here](https://github.com/GNOME/librsvg).
 
-## Usage
+## Getting Started
 
-You can run awscli to manage your AWS services.
+This image can be used with the docker type for different types of continuous integration platforms. For example:
 
-```bash
-aws iam list-users
-aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
-aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              uses: docker://ghcr.io/cardboardci/rsvg:edge
+              with:
+                  args: "rsvg --version"
 ```
 
 ### Pull latest image
 
+The edge or latest version of the image is available with the tag `edge`. This isn't intended to long term use, but for working with the latest version of the image. To pull the latest image, run the following:
+
 ```bash
-docker pull cardboardci/rsvg
+docker pull ghcr.io/cardboardci/rsvg:edge
 ```
 
 ### Test interactively
 
+Sometimes it can be useful to run the image in an interactive shell for experimentation. To shell into an image, run the following:
+
 ```bash
-docker run -it cardboardci/rsvg /bin/bash
+docker run -it ghcr.io/cardboardci/rsvg:edge /bin/bash
 ```
 
 ### Run basic AWS command
 
-```bash
-docker run -it -v "$(pwd)":/workspace cardboardci/rsvg aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Run AWS CLI with custom profile
+To run a single command from the context of the docker image, run the following:
 
 ```bash
-docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/rsvg aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Continuous Integration Services
-
-For each of the following services, you can see an example of this image in that environment:
-
-* [CircleCI](usages/circleci)
-* [GitHub Actions](usages/github)
-* [GitLabCI](usages/gitlabci)
-* [JenkinsFile](usages/jenkins)
-* [TravisCI](usages/travisci)
-* [Codeship](usages/codeship)
-
-## Tagging Strategy
-
-Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
-
-* `latest`: The most-recently released version of an image. (`cardboardci/rsvg:latest`)
-* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/rsvg:1.0.0`)
-* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
-
-We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
-
-```bash
-docker pull cardboardci/rsvg:latest
-docker inspect --format='{{index .RepoDigests 0}}' cardboardci/rsvg:latest
+docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/rsvg:edge aws --version
 ```
 
 ## Fundamentals
 
-All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
-
-By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.
+All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.

--- a/images/rubocop/README.md
+++ b/images/rubocop/README.md
@@ -1,6 +1,6 @@
 # cardboardci/rubocop
 
-cardboardci/rubocop is a Docker image built with continuous integration builds in mind. Each tag contains an RuboCop version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
+cardboardci/rubocop is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment. This includes `jq`, `curl`, `bash` and utilities for static analysis of Ruby.
 
 RuboCop is a Ruby static code analyzer and code formatter. Out of the box it will enforce many of the guidelines outlined in the community Ruby Style Guide.
 
@@ -39,7 +39,7 @@ Sometimes it can be useful to run the image in an interactive shell for experime
 docker run -it ghcr.io/cardboardci/rubocop:edge /bin/bash
 ```
 
-### Run basic AWS command
+### Run a basic command
 
 To run a single command from the context of the docker image, run the following:
 

--- a/images/rubocop/README.md
+++ b/images/rubocop/README.md
@@ -1,4 +1,6 @@
-# Docker image for Rubocop
+# cardboardci/rubocop
+
+cardboardci/rubocop is a Docker image built with continuous integration builds in mind. Each tag contains an RuboCop version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
 
 RuboCop is a Ruby static code analyzer and code formatter. Out of the box it will enforce many of the guidelines outlined in the community Ruby Style Guide.
 
@@ -6,68 +8,45 @@ RuboCop is extremely flexible and most aspects of its behavior can be tweaked vi
 
 You can see the cli reference [here](https://github.com/rubocop-hq/rubocop).
 
-## Usage
+## Getting Started
 
-You can run awscli to manage your AWS services.
+This image can be used with the docker type for different types of continuous integration platforms. For example:
 
-```bash
-aws iam list-users
-aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
-aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              uses: docker://ghcr.io/cardboardci/rubocop:edge
+              with:
+                  args: "rubocop --version"
 ```
 
 ### Pull latest image
 
+The edge or latest version of the image is available with the tag `edge`. This isn't intended to long term use, but for working with the latest version of the image. To pull the latest image, run the following:
+
 ```bash
-docker pull cardboardci/rubocop
+docker pull ghcr.io/cardboardci/rubocop:edge
 ```
 
 ### Test interactively
 
+Sometimes it can be useful to run the image in an interactive shell for experimentation. To shell into an image, run the following:
+
 ```bash
-docker run -it cardboardci/rubocop /bin/bash
+docker run -it ghcr.io/cardboardci/rubocop:edge /bin/bash
 ```
 
 ### Run basic AWS command
 
-```bash
-docker run -it -v "$(pwd)":/workspace cardboardci/rubocop aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Run AWS CLI with custom profile
+To run a single command from the context of the docker image, run the following:
 
 ```bash
-docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/rubocop aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Continuous Integration Services
-
-For each of the following services, you can see an example of this image in that environment:
-
-* [CircleCI](usages/circleci)
-* [GitHub Actions](usages/github)
-* [GitLabCI](usages/gitlabci)
-* [JenkinsFile](usages/jenkins)
-* [TravisCI](usages/travisci)
-* [Codeship](usages/codeship)
-
-## Tagging Strategy
-
-Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
-
-* `latest`: The most-recently released version of an image. (`cardboardci/rubocop:latest`)
-* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/rubocop:1.0.0`)
-* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
-
-We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
-
-```bash
-docker pull cardboardci/rubocop:latest
-docker inspect --format='{{index .RepoDigests 0}}' cardboardci/rubocop:latest
+docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/rubocop:edge aws --version
 ```
 
 ## Fundamentals
 
-All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
-
-By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.
+All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.

--- a/images/shellcheck/README.md
+++ b/images/shellcheck/README.md
@@ -1,6 +1,6 @@
 # cardboardci/shellcheck
 
-cardboardci/shellcheck is a Docker image built with continuous integration builds in mind. Each tag contains an ShellCheck version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
+cardboardci/shellcheck is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment. This includes `jq`, `curl`, `bash` and utilities for static analysis of Shell scripts.
 
 ShellCheck is a GPLv3 tool that gives warnings and suggestions for bash/sh shell scripts:
 
@@ -43,7 +43,7 @@ Sometimes it can be useful to run the image in an interactive shell for experime
 docker run -it ghcr.io/cardboardci/shellcheck:edge /bin/bash
 ```
 
-### Run basic AWS command
+### Run a basic command
 
 To run a single command from the context of the docker image, run the following:
 

--- a/images/shellcheck/README.md
+++ b/images/shellcheck/README.md
@@ -1,77 +1,56 @@
-# Docker image for Shellcheck
+# cardboardci/shellcheck
+
+cardboardci/shellcheck is a Docker image built with continuous integration builds in mind. Each tag contains an ShellCheck version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
 
 ShellCheck is a GPLv3 tool that gives warnings and suggestions for bash/sh shell scripts:
 
 The goals of ShellCheck are:
 
-* To point out and clarify typical beginner's syntax issues that cause a shell to give cryptic error messages.
-* To point out and clarify typical intermediate level semantic problems that cause a shell to behave strangely and counter-intuitively.
-* To point out subtle caveats, corner cases and pitfalls that may cause an advanced user's otherwise working script to fail under future circumstances.
+-   To point out and clarify typical beginner's syntax issues that cause a shell to give cryptic error messages.
+-   To point out and clarify typical intermediate level semantic problems that cause a shell to behave strangely and counter-intuitively.
+-   To point out subtle caveats, corner cases and pitfalls that may cause an advanced user's otherwise working script to fail under future circumstances.
 
 You can see the cli reference [here](https://github.com/koalaman/shellcheck).
 
-## Usage
+## Getting Started
 
-You can run awscli to manage your AWS services.
+This image can be used with the docker type for different types of continuous integration platforms. For example:
 
-```bash
-aws iam list-users
-aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
-aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              uses: docker://ghcr.io/cardboardci/shellcheck:edge
+              with:
+                  args: "shellcheck --version"
 ```
 
 ### Pull latest image
 
+The edge or latest version of the image is available with the tag `edge`. This isn't intended to long term use, but for working with the latest version of the image. To pull the latest image, run the following:
+
 ```bash
-docker pull cardboardci/shellcheck
+docker pull ghcr.io/cardboardci/shellcheck:edge
 ```
 
 ### Test interactively
 
+Sometimes it can be useful to run the image in an interactive shell for experimentation. To shell into an image, run the following:
+
 ```bash
-docker run -it cardboardci/shellcheck /bin/bash
+docker run -it ghcr.io/cardboardci/shellcheck:edge /bin/bash
 ```
 
 ### Run basic AWS command
 
-```bash
-docker run -it -v "$(pwd)":/workspace cardboardci/shellcheck aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Run AWS CLI with custom profile
+To run a single command from the context of the docker image, run the following:
 
 ```bash
-docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/shellcheck aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Continuous Integration Services
-
-For each of the following services, you can see an example of this image in that environment:
-
-* [CircleCI](usages/circleci)
-* [GitHub Actions](usages/github)
-* [GitLabCI](usages/gitlabci)
-* [JenkinsFile](usages/jenkins)
-* [TravisCI](usages/travisci)
-* [Codeship](usages/codeship)
-
-## Tagging Strategy
-
-Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
-
-* `latest`: The most-recently released version of an image. (`cardboardci/shellcheck:latest`)
-* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/shellcheck:1.0.0`)
-* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
-
-We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
-
-```bash
-docker pull cardboardci/shellcheck:latest
-docker inspect --format='{{index .RepoDigests 0}}' cardboardci/shellcheck:latest
+docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/shellcheck:edge aws --version
 ```
 
 ## Fundamentals
 
-All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
-
-By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.
+All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.

--- a/images/stylelint/README.md
+++ b/images/stylelint/README.md
@@ -1,83 +1,62 @@
-# Docker image for StyleLint
+# cardboardci/stylelint
+
+cardboardci/stylelint is a Docker image built with continuous integration builds in mind. Each tag contains an stylelint version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
 
 A mighty, modern linter that helps you avoid errors and enforce conventions in your styles.
 
 It's mighty because it:
 
-* understands the latest CSS syntax including custom properties and level 4 selectors
-* extracts embedded styles from HTML, markdown and CSS-in-JS object & template literals
-* parses CSS-like syntaxes like SCSS, Sass, Less and SugarSS
-* has over 170 built-in rules to catch errors, apply limits and enforce stylistic conventions
-* supports plugins so you can create your own rules or make use of plugins written by the community
-* automatically fixes some violations (experimental feature)
-* is well tested with over 10000 unit tests
-* supports shareable configs that you can extend or create your own of
-* is unopinionated so you can tailor the linter to your exact needs
+-   understands the latest CSS syntax including custom properties and level 4 selectors
+-   extracts embedded styles from HTML, markdown and CSS-in-JS object & template literals
+-   parses CSS-like syntaxes like SCSS, Sass, Less and SugarSS
+-   has over 170 built-in rules to catch errors, apply limits and enforce stylistic conventions
+-   supports plugins so you can create your own rules or make use of plugins written by the community
+-   automatically fixes some violations (experimental feature)
+-   is well tested with over 10000 unit tests
+-   supports shareable configs that you can extend or create your own of
+-   is unopinionated so you can tailor the linter to your exact needs
 
 You can see the cli reference [here](https://github.com/stylelint/stylelint).
 
-## Usage
+## Getting Started
 
-You can run awscli to manage your AWS services.
+This image can be used with the docker type for different types of continuous integration platforms. For example:
 
-```bash
-aws iam list-users
-aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
-aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              uses: docker://ghcr.io/cardboardci/stylelint:edge
+              with:
+                  args: "stylelint --version"
 ```
 
 ### Pull latest image
 
+The edge or latest version of the image is available with the tag `edge`. This isn't intended to long term use, but for working with the latest version of the image. To pull the latest image, run the following:
+
 ```bash
-docker pull cardboardci/stylelint
+docker pull ghcr.io/cardboardci/stylelint:edge
 ```
 
 ### Test interactively
 
+Sometimes it can be useful to run the image in an interactive shell for experimentation. To shell into an image, run the following:
+
 ```bash
-docker run -it cardboardci/stylelint /bin/bash
+docker run -it ghcr.io/cardboardci/stylelint:edge /bin/bash
 ```
 
 ### Run basic AWS command
 
-```bash
-docker run -it -v "$(pwd)":/workspace cardboardci/stylelint aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Run AWS CLI with custom profile
+To run a single command from the context of the docker image, run the following:
 
 ```bash
-docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/stylelint aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Continuous Integration Services
-
-For each of the following services, you can see an example of this image in that environment:
-
-* [CircleCI](usages/circleci)
-* [GitHub Actions](usages/github)
-* [GitLabCI](usages/gitlabci)
-* [JenkinsFile](usages/jenkins)
-* [TravisCI](usages/travisci)
-* [Codeship](usages/codeship)
-
-## Tagging Strategy
-
-Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
-
-* `latest`: The most-recently released version of an image. (`cardboardci/stylelint:latest`)
-* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/stylelint:1.0.0`)
-* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
-
-We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
-
-```bash
-docker pull cardboardci/stylelint:latest
-docker inspect --format='{{index .RepoDigests 0}}' cardboardci/stylelint:latest
+docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/stylelint:edge aws --version
 ```
 
 ## Fundamentals
 
-All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
-
-By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.
+All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.

--- a/images/stylelint/README.md
+++ b/images/stylelint/README.md
@@ -1,6 +1,6 @@
 # cardboardci/stylelint
 
-cardboardci/stylelint is a Docker image built with continuous integration builds in mind. Each tag contains an stylelint version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
+cardboardci/stylelint is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment. This includes `jq`, `curl`, `bash` and utilities for linting modern web files.
 
 A mighty, modern linter that helps you avoid errors and enforce conventions in your styles.
 
@@ -49,7 +49,7 @@ Sometimes it can be useful to run the image in an interactive shell for experime
 docker run -it ghcr.io/cardboardci/stylelint:edge /bin/bash
 ```
 
-### Run basic AWS command
+### Run a basic command
 
 To run a single command from the context of the docker image, run the following:
 

--- a/images/surge/README.md
+++ b/images/surge/README.md
@@ -1,6 +1,6 @@
 # cardboardci/surge
 
-cardboardci/surge is a Docker image built with continuous integration builds in mind. Each tag contains an surge.sh version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
+cardboardci/surge is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment. This includes `jq`, `curl`, `bash` and utilities for deploying to surge.sh.
 
 This is the CLI client for the surge.sh hosted service. It’s what gets installed when you run `npm install -g surge`.
 
@@ -39,7 +39,7 @@ Sometimes it can be useful to run the image in an interactive shell for experime
 docker run -it ghcr.io/cardboardci/surge:edge /bin/bash
 ```
 
-### Run basic AWS command
+### Run a basic command
 
 To run a single command from the context of the docker image, run the following:
 

--- a/images/surge/README.md
+++ b/images/surge/README.md
@@ -1,4 +1,6 @@
-# Docker image for Surge
+# cardboardci/surge
+
+cardboardci/surge is a Docker image built with continuous integration builds in mind. Each tag contains an surge.sh version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
 
 This is the CLI client for the surge.sh hosted service. It’s what gets installed when you run `npm install -g surge`.
 
@@ -6,68 +8,45 @@ This CLI library manages access tokens locally and handles the upload and subseq
 
 You can see the cli reference [here](https://github.com/sintaxi/surge).
 
-## Usage
+## Getting Started
 
-You can run awscli to manage your AWS services.
+This image can be used with the docker type for different types of continuous integration platforms. For example:
 
-```bash
-aws iam list-users
-aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
-aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              uses: docker://ghcr.io/cardboardci/surge:edge
+              with:
+                  args: "surge --version"
 ```
 
 ### Pull latest image
 
+The edge or latest version of the image is available with the tag `edge`. This isn't intended to long term use, but for working with the latest version of the image. To pull the latest image, run the following:
+
 ```bash
-docker pull cardboardci/surge
+docker pull ghcr.io/cardboardci/surge:edge
 ```
 
 ### Test interactively
 
+Sometimes it can be useful to run the image in an interactive shell for experimentation. To shell into an image, run the following:
+
 ```bash
-docker run -it cardboardci/surge /bin/bash
+docker run -it ghcr.io/cardboardci/surge:edge /bin/bash
 ```
 
 ### Run basic AWS command
 
-```bash
-docker run -it -v "$(pwd)":/workspace cardboardci/surge aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Run AWS CLI with custom profile
+To run a single command from the context of the docker image, run the following:
 
 ```bash
-docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/surge aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Continuous Integration Services
-
-For each of the following services, you can see an example of this image in that environment:
-
-* [CircleCI](usages/circleci)
-* [GitHub Actions](usages/github)
-* [GitLabCI](usages/gitlabci)
-* [JenkinsFile](usages/jenkins)
-* [TravisCI](usages/travisci)
-* [Codeship](usages/codeship)
-
-## Tagging Strategy
-
-Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
-
-* `latest`: The most-recently released version of an image. (`cardboardci/surge:latest`)
-* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/surge:1.0.0`)
-* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
-
-We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
-
-```bash
-docker pull cardboardci/surge:latest
-docker inspect --format='{{index .RepoDigests 0}}' cardboardci/surge:latest
+docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/surge:edge aws --version
 ```
 
 ## Fundamentals
 
-All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
-
-By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.
+All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.

--- a/images/svgtools/README.md
+++ b/images/svgtools/README.md
@@ -1,71 +1,50 @@
-# Docker image for SVG Tools
+# cardboardci/svgtools
+
+cardboardci/svgtools is a Docker image built with continuous integration builds in mind. Each tag any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
 
 SVG Tools are a collection of tools for working with vector graphics.
 
 You can see the cli reference [here](https://github.com/inkscape/inkscape).
 
-## Usage
+## Getting Started
 
-You can run awscli to manage your AWS services.
+This image can be used with the docker type for different types of continuous integration platforms. For example:
 
-```bash
-aws iam list-users
-aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
-aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              uses: docker://ghcr.io/cardboardci/svgtools:edge
+              with:
+                  args: "rsvg --version"
 ```
 
 ### Pull latest image
 
+The edge or latest version of the image is available with the tag `edge`. This isn't intended to long term use, but for working with the latest version of the image. To pull the latest image, run the following:
+
 ```bash
-docker pull cardboardci/svgtools
+docker pull ghcr.io/cardboardci/svgtools:edge
 ```
 
 ### Test interactively
 
+Sometimes it can be useful to run the image in an interactive shell for experimentation. To shell into an image, run the following:
+
 ```bash
-docker run -it cardboardci/svgtools /bin/bash
+docker run -it ghcr.io/cardboardci/svgtools:edge /bin/bash
 ```
 
 ### Run basic AWS command
 
-```bash
-docker run -it -v "$(pwd)":/workspace cardboardci/svgtools aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Run AWS CLI with custom profile
+To run a single command from the context of the docker image, run the following:
 
 ```bash
-docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/svgtools aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Continuous Integration Services
-
-For each of the following services, you can see an example of this image in that environment:
-
-* [CircleCI](usages/circleci)
-* [GitHub Actions](usages/github)
-* [GitLabCI](usages/gitlabci)
-* [JenkinsFile](usages/jenkins)
-* [TravisCI](usages/travisci)
-* [Codeship](usages/codeship)
-
-## Tagging Strategy
-
-Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
-
-* `latest`: The most-recently released version of an image. (`cardboardci/svgtools:latest`)
-* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/svgtools:1.0.0`)
-* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
-
-We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
-
-```bash
-docker pull cardboardci/svgtools:latest
-docker inspect --format='{{index .RepoDigests 0}}' cardboardci/svgtools:latest
+docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/svgtools:edge aws --version
 ```
 
 ## Fundamentals
 
-All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
-
-By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.
+All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.

--- a/images/svgtools/README.md
+++ b/images/svgtools/README.md
@@ -1,6 +1,6 @@
 # cardboardci/svgtools
 
-cardboardci/svgtools is a Docker image built with continuous integration builds in mind. Each tag any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
+cardboardci/svgtools is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment. This includes `jq`, `curl`, `bash` and utilities for working with Scalable Vector Graphics (SVG).
 
 SVG Tools are a collection of tools for working with vector graphics.
 
@@ -37,7 +37,7 @@ Sometimes it can be useful to run the image in an interactive shell for experime
 docker run -it ghcr.io/cardboardci/svgtools:edge /bin/bash
 ```
 
-### Run basic AWS command
+### Run a basic command
 
 To run a single command from the context of the docker image, run the following:
 

--- a/images/tflint/README.md
+++ b/images/tflint/README.md
@@ -1,6 +1,6 @@
 # cardboardci/tflint
 
-cardboardci/tflint is a Docker image built with continuous integration builds in mind. Each tag contains an TFLint version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
+cardboardci/tflint is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment. This includes `jq`, `curl`, `bash` and utilities for static analysis of Terraform.
 
 TFLint is a Terraform linter focused on possible errors, best practices, etc.
 
@@ -37,7 +37,7 @@ Sometimes it can be useful to run the image in an interactive shell for experime
 docker run -it ghcr.io/cardboardci/tflint:edge /bin/bash
 ```
 
-### Run basic AWS command
+### Run a basic command
 
 To run a single command from the context of the docker image, run the following:
 

--- a/images/tflint/README.md
+++ b/images/tflint/README.md
@@ -1,71 +1,50 @@
-# Docker image for TfLint
+# cardboardci/tflint
+
+cardboardci/tflint is a Docker image built with continuous integration builds in mind. Each tag contains an TFLint version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
 
 TFLint is a Terraform linter focused on possible errors, best practices, etc.
 
 You can see the cli reference [here](https://github.com/terraform-linters/tflint).
 
-## Usage
+## Getting Started
 
-You can run awscli to manage your AWS services.
+This image can be used with the docker type for different types of continuous integration platforms. For example:
 
-```bash
-aws iam list-users
-aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
-aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              uses: docker://ghcr.io/cardboardci/tflint:edge
+              with:
+                  args: "awscli --version"
 ```
 
 ### Pull latest image
 
+The edge or latest version of the image is available with the tag `edge`. This isn't intended to long term use, but for working with the latest version of the image. To pull the latest image, run the following:
+
 ```bash
-docker pull cardboardci/tflint
+docker pull ghcr.io/cardboardci/tflint:edge
 ```
 
 ### Test interactively
 
+Sometimes it can be useful to run the image in an interactive shell for experimentation. To shell into an image, run the following:
+
 ```bash
-docker run -it cardboardci/tflint /bin/bash
+docker run -it ghcr.io/cardboardci/tflint:edge /bin/bash
 ```
 
 ### Run basic AWS command
 
-```bash
-docker run -it -v "$(pwd)":/workspace cardboardci/tflint aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Run AWS CLI with custom profile
+To run a single command from the context of the docker image, run the following:
 
 ```bash
-docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/tflint aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Continuous Integration Services
-
-For each of the following services, you can see an example of this image in that environment:
-
-* [CircleCI](usages/circleci)
-* [GitHub Actions](usages/github)
-* [GitLabCI](usages/gitlabci)
-* [JenkinsFile](usages/jenkins)
-* [TravisCI](usages/travisci)
-* [Codeship](usages/codeship)
-
-## Tagging Strategy
-
-Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
-
-* `latest`: The most-recently released version of an image. (`cardboardci/tflint:latest`)
-* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/tflint:1.0.0`)
-* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
-
-We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
-
-```bash
-docker pull cardboardci/tflint:latest
-docker inspect --format='{{index .RepoDigests 0}}' cardboardci/tflint:latest
+docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/tflint:edge aws --version
 ```
 
 ## Fundamentals
 
-All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
-
-By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.
+All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.

--- a/images/wkhtmltopdf/README.md
+++ b/images/wkhtmltopdf/README.md
@@ -1,6 +1,6 @@
 # cardboardci/wkhtmltopdf
 
-cardboardci/wkhtmltopdf is a Docker image built with continuous integration builds in mind. Each tag contains an wkhtmltopdf version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
+cardboardci/wkhtmltopdf is a Docker image built with continuous integration builds in mind. Each tag contains any binaries and tools that are required for builds to complete successfully in a continuous integration environment. This includes `jq`, `curl`, `bash` and utilities for converting from HTML to PDF.
 
 wkhtmltopdf and wkhtmltoimage are open source (LGPLv3) command line tools to render HTML into PDF and various image formats using the Qt WebKit rendering engine. These run entirely "headless" and do not require a display or display service.
 
@@ -37,7 +37,7 @@ Sometimes it can be useful to run the image in an interactive shell for experime
 docker run -it ghcr.io/cardboardci/wkhtmltopdf:edge /bin/bash
 ```
 
-### Run basic AWS command
+### Run a basic command
 
 To run a single command from the context of the docker image, run the following:
 

--- a/images/wkhtmltopdf/README.md
+++ b/images/wkhtmltopdf/README.md
@@ -1,71 +1,50 @@
-# Docker image for WkHtmlToPDF
+# cardboardci/wkhtmltopdf
+
+cardboardci/wkhtmltopdf is a Docker image built with continuous integration builds in mind. Each tag contains an wkhtmltopdf version and any binaries and tools that are required for builds to complete successfully in a continuous integration environment.
 
 wkhtmltopdf and wkhtmltoimage are open source (LGPLv3) command line tools to render HTML into PDF and various image formats using the Qt WebKit rendering engine. These run entirely "headless" and do not require a display or display service.
 
 You can see the cli reference [here](https://github.com/wkhtmltopdf/wkhtmltopdf).
 
-## Usage
+## Getting Started
 
-You can run awscli to manage your AWS services.
+This image can be used with the docker type for different types of continuous integration platforms. For example:
 
-```bash
-aws iam list-users
-aws s3 cp /tmp/foo/ s3://bucket/ --recursive --exclude "*" --include "*.jpg"
-aws sts assume-role --role-arn arn:aws:iam::123456789012:role/xaccounts3access --role-session-name s3-access-example
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              uses: docker://ghcr.io/cardboardci/wkhtmltopdf:edge
+              with:
+                  args: "wkhtmltopdf --version"
 ```
 
 ### Pull latest image
 
+The edge or latest version of the image is available with the tag `edge`. This isn't intended to long term use, but for working with the latest version of the image. To pull the latest image, run the following:
+
 ```bash
-docker pull cardboardci/wkhtmltopdf
+docker pull ghcr.io/cardboardci/wkhtmltopdf:edge
 ```
 
 ### Test interactively
 
+Sometimes it can be useful to run the image in an interactive shell for experimentation. To shell into an image, run the following:
+
 ```bash
-docker run -it cardboardci/wkhtmltopdf /bin/bash
+docker run -it ghcr.io/cardboardci/wkhtmltopdf:edge /bin/bash
 ```
 
 ### Run basic AWS command
 
-```bash
-docker run -it -v "$(pwd)":/workspace cardboardci/wkhtmltopdf aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Run AWS CLI with custom profile
+To run a single command from the context of the docker image, run the following:
 
 ```bash
-docker run -it -v "$(pwd)":/workspace -v "~/.aws/":/cardboardci/.aws/ cardboardci/wkhtmltopdf aws s3 cp file.txt s3://bucket/file.txt
-```
-
-### Continuous Integration Services
-
-For each of the following services, you can see an example of this image in that environment:
-
-* [CircleCI](usages/circleci)
-* [GitHub Actions](usages/github)
-* [GitLabCI](usages/gitlabci)
-* [JenkinsFile](usages/jenkins)
-* [TravisCI](usages/travisci)
-* [Codeship](usages/codeship)
-
-## Tagging Strategy
-
-Every new release of the image includes three tags: version, date and `latest`. These tags can be described as such:
-
-* `latest`: The most-recently released version of an image. (`cardboardci/wkhtmltopdf:latest`)
-* `<version>`: The most-recently released version of an image for that version of the tool. (`cardboardci/wkhtmltopdf:1.0.0`)
-* `<version-date>`: The version of the tool released on a specific date (`cardboarci/awscli:1.0.0-20190101`)
-
-We recommend using the digest for the docker image, or pinning to the version-date tag. If you are unsure how to get the digest, you can retrieve it for any image with the following command:
-
-```bash
-docker pull cardboardci/wkhtmltopdf:latest
-docker inspect --format='{{index .RepoDigests 0}}' cardboardci/wkhtmltopdf:latest
+docker run -it -v `pwd`:/workspace ghcr.io/cardboardci/wkhtmltopdf:edge aws --version
 ```
 
 ## Fundamentals
 
-All images in the CardboardCI namespace are built from [cardboardci/ci-core](https://hub.docker.com/r/cardboardci/ci-core). This image ensures that the base environment for every image is always up to date. The [common base image](https://cardboardci.jrbeverly.dev/core/) provides dependencies that are often used building and deploying software.
-
-By having a common base, it means that each image is able to focus on providing the optimal tooling for each development workflow.
+All images in the CardboardCI namespace are built from cardboardci/base. This image is intended to provide a common set of dependencies and expectations about how the images will behave. The image will always be built from the base image, to ensure any changes seen in the base are included in the downstream image.


### PR DESCRIPTION
Configure a standard template for all of the images.

This setups a common way of viewing each of the images on the cardboardci webpage, and understanding how to interact with them. The README doesn't need to contain any common test samples or use cases, as that can be baked into the images labels, then understood by the caller.