### PR TITLE
refactor(git): Change default branch to main

### DIFF
--- a/.github/workflows/build.awscli.yml
+++ b/.github/workflows/build.awscli.yml
@@ -42,7 +42,7 @@ jobs:
           docker tag bazel/images/awscli:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.image.outputs.fullname}}

--- a/.github/workflows/build.base.yml
+++ b/.github/workflows/build.base.yml
@@ -39,7 +39,7 @@ jobs:
           docker tag bazel/images/base:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.image.outputs.fullname}}

--- a/.github/workflows/build.bats.yml
+++ b/.github/workflows/build.bats.yml
@@ -42,7 +42,7 @@ jobs:
           docker tag bazel/images/bats:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.image.outputs.fullname}}

--- a/.github/workflows/build.cppcheck.yml
+++ b/.github/workflows/build.cppcheck.yml
@@ -42,7 +42,7 @@ jobs:
           docker tag bazel/images/cppcheck:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.image.outputs.fullname}}

--- a/.github/workflows/build.dbxcli.yml
+++ b/.github/workflows/build.dbxcli.yml
@@ -42,7 +42,7 @@ jobs:
           docker tag bazel/images/dbxcli:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.image.outputs.fullname}}

--- a/.github/workflows/build.ecr.yml
+++ b/.github/workflows/build.ecr.yml
@@ -42,7 +42,7 @@ jobs:
           docker tag bazel/images/ecr:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.image.outputs.fullname}}

--- a/.github/workflows/build.github.yml
+++ b/.github/workflows/build.github.yml
@@ -42,7 +42,7 @@ jobs:
           docker tag bazel/images/github:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.image.outputs.fullname}}

--- a/.github/workflows/build.gitlab.yml
+++ b/.github/workflows/build.gitlab.yml
@@ -42,7 +42,7 @@ jobs:
           docker tag bazel/images/gitlab:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.image.outputs.fullname}}

--- a/.github/workflows/build.hadolint.yml
+++ b/.github/workflows/build.hadolint.yml
@@ -42,7 +42,7 @@ jobs:
           docker tag bazel/images/hadolint:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.image.outputs.fullname}}

--- a/.github/workflows/build.htmlhint.yml
+++ b/.github/workflows/build.htmlhint.yml
@@ -42,7 +42,7 @@ jobs:
           docker tag bazel/images/htmlhint:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.image.outputs.fullname}}

--- a/.github/workflows/build.hugo.yml
+++ b/.github/workflows/build.hugo.yml
@@ -42,7 +42,7 @@ jobs:
           docker tag bazel/images/hugo:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.image.outputs.fullname}}

--- a/.github/workflows/build.luacheck.yml
+++ b/.github/workflows/build.luacheck.yml
@@ -42,7 +42,7 @@ jobs:
           docker tag bazel/images/luacheck:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.image.outputs.fullname}}

--- a/.github/workflows/build.markdownlint.yml
+++ b/.github/workflows/build.markdownlint.yml
@@ -42,7 +42,7 @@ jobs:
           docker tag bazel/images/markdownlint:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.image.outputs.fullname}}

--- a/.github/workflows/build.netlify.yml
+++ b/.github/workflows/build.netlify.yml
@@ -42,7 +42,7 @@ jobs:
           docker tag bazel/images/netlify:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.image.outputs.fullname}}

--- a/.github/workflows/build.pdf2htmlex.yml
+++ b/.github/workflows/build.pdf2htmlex.yml
@@ -40,7 +40,7 @@ jobs:
           docker tag bazel/images/pdf2htmlex:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.image.outputs.fullname}}

--- a/.github/workflows/build.pdftools.yml
+++ b/.github/workflows/build.pdftools.yml
@@ -42,7 +42,7 @@ jobs:
           docker tag bazel/images/pdftools:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.image.outputs.fullname}}

--- a/.github/workflows/build.psscriptanalyzer.yml
+++ b/.github/workflows/build.psscriptanalyzer.yml
@@ -43,7 +43,7 @@ jobs:
           docker tag bazel/images/psscriptanalyzer:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.image.outputs.fullname}}

--- a/.github/workflows/build.pylint.yml
+++ b/.github/workflows/build.pylint.yml
@@ -42,7 +42,7 @@ jobs:
           docker tag bazel/images/pylint:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.image.outputs.fullname}}

--- a/.github/workflows/build.rsvg.yml
+++ b/.github/workflows/build.rsvg.yml
@@ -42,7 +42,7 @@ jobs:
           docker tag bazel/images/rsvg:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.image.outputs.fullname}}

--- a/.github/workflows/build.rubocop.yml
+++ b/.github/workflows/build.rubocop.yml
@@ -42,7 +42,7 @@ jobs:
           docker tag bazel/images/rubocop:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.image.outputs.fullname}}

--- a/.github/workflows/build.shellcheck.yml
+++ b/.github/workflows/build.shellcheck.yml
@@ -42,7 +42,7 @@ jobs:
           docker tag bazel/images/shellcheck:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.image.outputs.fullname}}

--- a/.github/workflows/build.stylelint.yml
+++ b/.github/workflows/build.stylelint.yml
@@ -42,7 +42,7 @@ jobs:
           docker tag bazel/images/stylelint:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.image.outputs.fullname}}

--- a/.github/workflows/build.surge.yml
+++ b/.github/workflows/build.surge.yml
@@ -42,7 +42,7 @@ jobs:
           docker tag bazel/images/surge:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.image.outputs.fullname}}

--- a/.github/workflows/build.svgtools.yml
+++ b/.github/workflows/build.svgtools.yml
@@ -42,7 +42,7 @@ jobs:
           docker tag bazel/images/svgtools:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.image.outputs.fullname}}

--- a/.github/workflows/build.tflint.yml
+++ b/.github/workflows/build.tflint.yml
@@ -42,7 +42,7 @@ jobs:
           docker tag bazel/images/tflint:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.image.outputs.fullname}}

--- a/.github/workflows/build.wkhtmltopdf.yml
+++ b/.github/workflows/build.wkhtmltopdf.yml
@@ -42,7 +42,7 @@ jobs:
           docker tag bazel/images/wkhtmltopdf:image ${{ steps.image.outputs.image }}:edge
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push ${{ steps.image.outputs.fullname}}

--- a/.github/workflows/upgrader.base.yml
+++ b/.github/workflows/upgrader.base.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           username: jrbeverly
           email: jonathan@jrbeverly.me
-          branch: 'base-image-to-${{ steps.tag.outputs.image-tag }}'
+          branch: "base-image-to-${{ steps.tag.outputs.image-tag }}"
           token: ${{ secrets.CARDBOARDCI_PAT_TOKEN }}
       - name: Buildozer to edit digest
         if: ${{ steps.digest.outputs.image-digest != steps.source.outputs.image-digest }}
@@ -58,7 +58,7 @@ jobs:
           git add -f WORKSPACE
       - name: Commit all of the dependencies
         uses: ./.github/actions/git-commit
-        if: ${{ steps.digest.outputs.image-digest != steps.source.outputs.image-digest && github.ref == 'refs/heads/master' }}
+        if: ${{ steps.digest.outputs.image-digest != steps.source.outputs.image-digest && github.ref == 'refs/heads/main' }}
         env:
           GITHUB_TOKEN: ${{ secrets.CARDBOARDCI_PAT_TOKEN }}
         with:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -26,7 +26,7 @@ jobs:
           tar -xf website.tar
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@releases/v3
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages

--- a/docs/www/common-base-image.md
+++ b/docs/www/common-base-image.md
@@ -54,7 +54,7 @@ cardboardci/base:edge[-version]
 cardboardci/base:<YYYYMMDD>[-version]
 ```
 
-edge - This image tag points to the latest version of the Base image. This tag is built from the HEAD of the master branch. The edge tag is intended to be used as a reference version of the image before referencing by either tag or sha. This tag should not be used in continuous integration settings unless experimenting.
+edge - This image tag points to the latest version of the Base image. This tag is built from the HEAD of the main branch. The edge tag is intended to be used as a reference version of the image before referencing by either tag or sha. This tag should not be used in continuous integration settings unless experimenting.
 
 <YYYYMMDD> - This image tag is a build of the image, referred to by the 4 digit year, a 2 digit month, and the 2 digit day. For example 20210919 would be the build from September 19th 2021. This tag is intended for cases where image usages are frequently updated.
 

--- a/docs/www/conventions/tagging.md
+++ b/docs/www/conventions/tagging.md
@@ -7,7 +7,7 @@ cardboardci/<name>:edge[-version]
 cardboardci/<name>:<YYYYMMDD>[-version]
 ```
 
-edge - This image tag points to the latest version of the image. This tag is built from the HEAD of the master branch. The edge tag is intended to be used as a reference version of the image before referencing by either tag or sha. This tag should not be used in continuous integration settings unless experimenting.
+edge - This image tag points to the latest version of the image. This tag is built from the HEAD of the main branch. The edge tag is intended to be used as a reference version of the image before referencing by either tag or sha. This tag should not be used in continuous integration settings unless experimenting.
 
 <YYYYMMDD> - This image tag is a build of the image, referred to by the 4 digit year, a 2 digit month, and the 2 digit day. For example 20210919 would be the build from September 19th 2021. This tag is intended for cases where image usages are frequently updated.
 

--- a/rules/images.bzl
+++ b/rules/images.bzl
@@ -28,7 +28,7 @@ def cardboardci_image(name, base, labels, tars = []):
             "org.opencontainers.image.summary": labels["org.opencontainers.image.summary"],
             "org.opencontainers.image.description": labels["org.opencontainers.image.description"],
             "org.opencontainers.image.source": "https://github.com/cardboardci/dockerfiles/images/%s" % (labels["org.opencontainers.image.title"]),
-            "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/tree/master/images/%s" % (labels["org.opencontainers.image.title"]),
+            "org.opencontainers.image.url": "https://github.com/cardboardci/dockerfiles/tree/main/images/%s" % (labels["org.opencontainers.image.title"]),
             "org.opencontainers.image.documentation": "https://cardboardci.jrbeverly.me",
             "org.cardboardci.image.user": "cardboardci",
             "org.cardboardci.image.group": "cardboardci",


### PR DESCRIPTION
Change the primary branch of this repository to match the new convention.

Adopt `main` as the primary branch name for this repository, as new repositories are by default created with the branch `main`. This is intended to ensure all repositories match similar conventions for automation.