### PR TITLE
docs(usages): Cleanup the usage documentation

### DIFF
--- a/docs/tools/get-images-table.bash
+++ b/docs/tools/get-images-table.bash
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+for img in *
+do
+    if [ "$img" != "base" ]
+    then 
+        description=$(buildozer 'print labels' "//images/$img:image" | sed 'x;${s/,$//;p;x;};1d' | jq -r '."org.opencontainers.image.description"')
+        echo "| [**cardboardci/${img}**](images/${img}) | ${description} |"
+    fi
+done

--- a/docs/www/README.md
+++ b/docs/www/README.md
@@ -1,18 +1,38 @@
-# CardboardCI
+# Introduction
 
-A collection of docker images that provide a common core for use in continuous integration.
+CardboardCI is a collection of several Docker images intended to be used for continuous integration. All of the images are pre-built and made available through the GitHub Container Registry, but built with the intentions to be usable to with any registry. These images are intended to upgrade automatically and enforce a series of constraints to ensure that they all behave similarly.
 
-The idea of these images is to balance the following:
+## Intentions
 
-- Frequency of updates
-- Standard set of tooling
-- Common Environment
+The images in this organization were built with efficiency, caching and determinism in mind. They are built using Bazel, with a base image responsible for ensuring core depdendencies are included in all images. The images are intended to be upgraded automatically when dependency upgrades are detected. These will raise a pull request, and automatically merge if the pull request successfully completes the checks.
 
-## Status
+## Images
 
-Project is still is progress, documentation is lacking, progress will evolve over time. Aims as below:
-
-- Dependencies are pinned
-- Dependencies are updated automatically by GitHub Actions
-- Images have basic documentation for common usages (GitHub Actions / etc)
-- Tests verifying aspects of each image (/tmp empty, metadata set)
+| IMAGE NAME                                                  | DESCRIPTION                                                                                            |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| [**cardboardci/base**](images/base)                         | A base image with common dependencies for CI environments                                              |
+| [**cardboardci/awscli**](images/awscli)                     | The AWS Command Line Interface (CLI) is a unified tool to manage your AWS services                     |
+| [**cardboardci/bats**](images/bats)                         | Bats is most useful when testing software written in Bash, but you can use it to test any UNIX program |
+| [**cardboardci/cppcheck**](images/cppcheck)                 | Static analysis of C/C++ code                                                                          |
+| [**cardboardci/dbxcli**](images/dbxcli)                     | A command line client for Dropbox built using the Go SDK.                                              |
+| [**cardboardci/ecr**](images/ecr)                           | A unified tool to deploy Docker images to Amazon Elastic Container Registry (ECR)                      |
+| [**cardboardci/github**](images/github)                     | A command-line tool that makes git easier to use with GitHub                                           |
+| [**cardboardci/gitlab**](images/gitlab)                     | Lab wraps Git or Hub, making it simple to clone, fork, and interact with repositories on GitLab        |
+| [**cardboardci/hadolint**](images/hadolint)                 | Dockerfile linter, validate inline bash, written in Haskell                                            |
+| [**cardboardci/htmlhint**](images/htmlhint)                 | The static code analysis tool you need for your HTML                                                   |
+| [**cardboardci/hugo**](images/hugo)                         | Hugo is an open-source static site generator                                                           |
+| [**cardboardci/luacheck**](images/luacheck)                 | Luacheck is a static analyzer and a linter for Lua                                                     |
+| [**cardboardci/markdownlint**](images/markdownlint)         | A Node.js style checker and lint tool for Markdown/CommonMark files                                    |
+| [**cardboardci/netlify**](images/netlify)                   | Netlify builds, deploys and hosts your netlify services                                                |
+| [**cardboardci/pdf2htmlex**](images/pdf2htmlex)             | Convert PDF to HTML without losing text or format                                                      |
+| [**cardboardci/pdftools**](images/pdftools)                 | Command line tools for manipulating pdfs                                                               |
+| [**cardboardci/psscriptanalyzer**](images/psscriptanalyzer) | PSScriptAnalyzer is a static code checker for Windows PowerShell modules and scripts                   |
+| [**cardboardci/pylint**](images/pylint)                     | Pylint is a Python static code analysis tool which looks for programming errors                        |
+| [**cardboardci/rsvg**](images/rsvg)                         | Turn SVG files into raster images                                                                      |
+| [**cardboardci/rubocop**](images/rubocop)                   | A Ruby static code analyzer and formatter, based on the community Ruby style guide                     |
+| [**cardboardci/shellcheck**](images/shellcheck)             | ShellCheck is a static anaylsis tool that automatically finds bugs in your shell scripts               |
+| [**cardboardci/stylelint**](images/stylelint)               | A mighty, modern style linter                                                                          |
+| [**cardboardci/surge**](images/surge)                       | Surge is static web publishing for Front-End Developers, right from the CLI                            |
+| [**cardboardci/svgtools**](images/svgtools)                 | Tools for working with Scalable Vector Graphics (SVG) files                                            |
+| [**cardboardci/tflint**](images/tflint)                     | TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan           |
+| [**cardboardci/wkhtmltopdf**](images/wkhtmltopdf)           | wkhtmltopdf is a command line tools to render HTML into PDF                                            |

--- a/docs/www/common-base-image.md
+++ b/docs/www/common-base-image.md
@@ -4,7 +4,7 @@ cardboardci/base is an Ubuntu Docker image created with reproducibility in mind.
 
 Any image developed should use this as a base image to avoid unique image configurations that do not work as expected.
 
-# Getting Started
+## Getting Started
 
 This image is intended to be inherited by other images, either with a Dockerfile or through Bazel builds. The following is a Dockerfile example:
 
@@ -33,7 +33,7 @@ install_pkgs(
 )
 ```
 
-# How This Image Works
+## How This Image Works
 
 This image contains the Ubuntu Linux operating system and everything that is considered common among all of the images. This includes but is not limited to:
 
@@ -45,7 +45,7 @@ This image contains the Ubuntu Linux operating system and everything that is con
 
 The full list can be seen in the `images/base` definition. All images are expected to have these configured and running in the environments.
 
-# Tagging Scheme
+## Tagging Scheme
 
 This image has the following tagging scheme:
 
@@ -54,8 +54,6 @@ cardboardci/base:edge[-version]
 cardboardci/base:<YYYYMMDD>[-version]
 ```
 
-edge - This image tag points to the latest version of the Base image. This tag is built from the HEAD of the main branch. The edge tag is intended to be used as a reference version of the image before referencing by either tag or sha. This tag should not be used in continuous integration settings unless experimenting.
-
-<YYYYMMDD> - This image tag is a build of the image, referred to by the 4 digit year, a 2 digit month, and the 2 digit day. For example 20210919 would be the build from September 19th 2021. This tag is intended for cases where image usages are frequently updated.
-
--version - This is an optional extension to the tag to specify variants of the image.
+-   `edge` - This image tag points to the latest version of the Base image. This tag is built from the HEAD of the main branch. The edge tag is intended to be used as a reference version of the image before referencing by either tag or sha. This tag should not be used in continuous integration settings unless experimenting.
+-   `<YYYYMMDD>` - This image tag is a build of the image, referred to by the 4 digit year, a 2 digit month, and the 2 digit day. For example 20210919 would be the build from September 19th 2021. This tag is intended for cases where image usages are frequently updated.
+-   `-version` - This is an optional extension to the tag to specify variants of the image.

--- a/docs/www/container-execution.md
+++ b/docs/www/container-execution.md
@@ -2,7 +2,7 @@
 
 You may find at some point you need to locally run the container or view the internal contents of the container.
 
-# Shell Access
+## Shell Access
 
 Particularly useful when you wish to work in a docker environment - to shell into a container, run the following:
 
@@ -18,7 +18,7 @@ docker exec -v `pwd`:/workspace -it <container_name> /bin/bash
 
 All images have `bash` installed.
 
-# Checking the build version
+## Checking the build version
 
 If you are experiencing issues with a container, it can be useful to determine the image digest. As each image is deterministic, the digest should map to specific versions.
 

--- a/docs/www/container-execution.md
+++ b/docs/www/container-execution.md
@@ -4,7 +4,7 @@ You may find at some point you need to locally run the container or view the int
 
 ## Shell Access
 
-Particularly useful when you wish to work in a docker environment - to shell into a container, run the following:
+If you are wishing to experiment with the container, it can be useful to start a shell session inside of the container - to shell into a container, run the following:
 
 ```bash
 docker exec -it <container_name> /bin/bash

--- a/docs/www/conventions/no-sudo.md
+++ b/docs/www/conventions/no-sudo.md
@@ -1,14 +1,14 @@
 # Limited Permissions
 
-The default user configured on each of the machines (`org.cardboardci.image.user`) does not have sudo permissions, and cannot install dependencies by default. Images are encouraged to be extended, rather than installing dependencies at runtime.
+The default user configured on each of the images (`org.cardboardci.image.user`) does not have sudo permissions, and cannot install dependencies by default. Images are encouraged to be extended, rather than installing dependencies at runtime.
 
-This can be inconvenient for experimentation with dependencies to resolve an issue, but is intended to ensure that any rogue dependency cannot sneak into the continuous integration system without going through the necessary vetting procedures to be installable.
+This can be inconvenient for experimentation with dependencies when trying to resolve an issue, but is intended to ensure that any rogue dependency cannot sneak into the software deployment pipeline without going through the necessary vetting procedures to be installable.
 
-Additionally avoiding installing at time of execution can avoid flakeyness in the build process for cdn outages, permanently removed resources, or failure to ensure dependency integrity.
+Additionally avoiding installation at runtime helps avoid flakeyness that can show up due to CDN outages, missing integrity checks or permanently moved resources.
 
 ## Pattern for Extension
 
-For extending the images, the following is a common Dockerfile pattern:
+To extend one of the images, the following is a common Dockerfile pattern:
 
 ```dockerfile
 FROM ghcr.io/cardboardci/base:20210211
@@ -22,8 +22,33 @@ RUN apt-get update && \
 USER cardboardci
 ```
 
+And the following is an example using Bazel:
+
+```starlark
+container_pull(
+    name = "cardboardci_base",
+    digest = "sha256:some_digest_value_here",
+    registry = "ghcr.io",
+    repository = "cardboardci/base",
+)
+
+download_pkgs(
+    name = "apt_get_download",
+    image_tar = "@cardboardci_base//image",
+    packages = [ ... ],
+)
+
+install_pkgs(
+    name = "apt_get_installed",
+    image_tar = "//images/base:image.tar",
+    installables_tar = ":apt_get_download.tar",
+    installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
+    output_image_name = "apt_get_installed",
+)
+```
+
 ## Chaining Images
 
-Although extending an image can be effective for tightly coupled utilities, chaining images is a preferred approach. This allows the images to be cached aggressively on build machines, as well as ensuring that each individual step clearly indicates the failure step.
+Extending images to add additional dependencies should be used when working with tightly coupled actions or behaviours. Otherwise it is recommended to chain images together leveraging 'steps' offered by most continuous integration services. Chaining images allows for aggressive caching on build machines, and clear failure scenarios for continuous integration pipelines.
 
-Large linting scripts in the continuous integration process can become unwieldy and be susceptible to complexity in dependency management.
+Bundling dependencies into large images can result in the pipeline becoming unwieldy and suspectible to dependency difficulties.

--- a/docs/www/conventions/tagging.md
+++ b/docs/www/conventions/tagging.md
@@ -7,11 +7,9 @@ cardboardci/<name>:edge[-version]
 cardboardci/<name>:<YYYYMMDD>[-version]
 ```
 
-edge - This image tag points to the latest version of the image. This tag is built from the HEAD of the main branch. The edge tag is intended to be used as a reference version of the image before referencing by either tag or sha. This tag should not be used in continuous integration settings unless experimenting.
-
-<YYYYMMDD> - This image tag is a build of the image, referred to by the 4 digit year, a 2 digit month, and the 2 digit day. For example 20210919 would be the build from September 19th 2021. This tag is intended for cases where image usages are frequently updated.
-
--version - This is an optional extension to the tag to specify variants of the image.
+-   `edge` - This image tag points to the latest version of the image. This tag is built from the HEAD of the main branch. The edge tag is intended to be used as a reference version of the image before referencing by either tag or sha. This tag should not be used in continuous integration settings unless experimenting.
+-   `<YYYYMMDD>` - This image tag is a build of the image, referred to by the 4 digit year, a 2 digit month, and the 2 digit day. For example 20210919 would be the build from September 19th 2021. This tag is intended for cases where image usages are frequently updated.
+-   `-version` - This is an optional extension to the tag to specify variants of the image.
 
 ## Recommended Usages
 

--- a/docs/www/conventions/tagging.md
+++ b/docs/www/conventions/tagging.md
@@ -15,4 +15,16 @@ cardboardci/<name>:<YYYYMMDD>[-version]
 
 The recommended usage is to use the SHA of the image with the tag included as a comment nearby. This uses the most precise version of the image, and includes a reference date for evaluating the age of the image itself.
 
-For cases where the image is updated frequently due to automation or source scanning, it is fine to make use of the tag.
+```yml
+# GitHub Actions
+jobs:
+    my_first_job:
+        steps:
+            - name: My first step
+              # 20210227
+              uses: docker://ghcr.io/cardboardci/basE@sha256:e99aef505e9e3a5026a9a2873f2a5e3b029adb5c8f70327672f3a9a7aef2c73a
+              with:
+                  args: "echo hello"
+```
+
+If the image is frequently updated due to automation, then using just the tag is a valid usage.

--- a/docs/www/conventions/user-and-group.md
+++ b/docs/www/conventions/user-and-group.md
@@ -33,7 +33,7 @@ Or the image:
 docker inspect -f '{{ index .Config.Labels "org.cardboardci.image.<property>" }}' ghcr.io/cardboardci/<image_name>
 ```
 
-# Checking the user
+## Checking the user
 
 If you are experiencing issues with one of the containers, it can be useful to check if the issue is due to permissions. Running the container with the root flag (`--user root`) or interactively debugging can be helpful.
 

--- a/docs/www/conventions/user-and-group.md
+++ b/docs/www/conventions/user-and-group.md
@@ -1,6 +1,6 @@
 # Understanding the User and Group
 
-Docker images often are configured to run in the `root` user domain of an image. This kind of elevated access for processes inside the container is not necessary. The common scenario for these images is to run as command working off the contents of a mounted volume.
+Docker images often are configured to run in the `root` user domain of an image. This kind of elevated access for processes inside the container is not necessary. The common scenario for these images is to run a command working off the contents of a mounted volume.
 
 Continuous integration services will often make use of the `--user` flag to use a reduced permission level for clusters. When running locally, the `--user` flag may not always be specified. In these cases, the cardboardci user acts as a user with minimum permissions to work with the `/workspace` directory.
 
@@ -14,12 +14,12 @@ docker run cardboardi/<image>:edge id
 
 ## Labels
 
-Properties of the default user for every image are made available with the label namespace `org.cardboardci.image.`. The following are properties that exist within this namespace:
+Properties of the default user for every image are made available with the label namespace `org.cardboardci.image.`. The following are user properties that exist within this namespace:
 
 -   `user` - The name of the default user
--   `uid` - The User identifier of the default user
+-   `uid` - The identifier of the default user
 -   `group` - The name of the default user group
--   `gid` - The Group identifier of the default user
+-   `gid` - The identifier of the default user group
 
 To obtain any of the properties listed above, you can run this for the container:
 
@@ -46,5 +46,5 @@ docker exec --user 'cardboardci' -it <container_name> /bin/bash
 Or as the root user:
 
 ```bash
-docker exec --user 'cardboardci' -it <container_name> /bin/bash
+docker exec --user 'root' -it <container_name> /bin/bash
 ```


### PR DESCRIPTION
Fixes to the language around how images are structured and used in the project.

The introduction page for the project has been rewritten to better act as a navigation point for the images.