### PR TITLE
fix(docs): Use dist not public

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -30,4 +30,4 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
-          FOLDER: public
+          FOLDER: dist


### PR DESCRIPTION
Path to the contents of the website should be `dist` instead of `public`