### PR TITLE
fix(build): Push all local tags

### DIFF
--- a/.github/workflows/build.awscli.yml
+++ b/.github/workflows/build.awscli.yml
@@ -45,4 +45,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ${{ steps.image.outputs.image}}
+          docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.base.yml
+++ b/.github/workflows/build.base.yml
@@ -42,4 +42,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ${{ steps.image.outputs.image}}
+          docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.bats.yml
+++ b/.github/workflows/build.bats.yml
@@ -45,4 +45,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ${{ steps.image.outputs.image}}
+          docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.cppcheck.yml
+++ b/.github/workflows/build.cppcheck.yml
@@ -45,4 +45,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ${{ steps.image.outputs.image}}
+          docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.dbxcli.yml
+++ b/.github/workflows/build.dbxcli.yml
@@ -45,4 +45,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ${{ steps.image.outputs.image}}
+          docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.ecr.yml
+++ b/.github/workflows/build.ecr.yml
@@ -45,4 +45,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ${{ steps.image.outputs.image}}
+          docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.github.yml
+++ b/.github/workflows/build.github.yml
@@ -45,4 +45,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ${{ steps.image.outputs.image}}
+          docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.gitlab.yml
+++ b/.github/workflows/build.gitlab.yml
@@ -45,4 +45,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ${{ steps.image.outputs.image}}
+          docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.hadolint.yml
+++ b/.github/workflows/build.hadolint.yml
@@ -45,4 +45,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ${{ steps.image.outputs.image}}
+          docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.htmlhint.yml
+++ b/.github/workflows/build.htmlhint.yml
@@ -45,4 +45,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ${{ steps.image.outputs.image}}
+          docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.hugo.yml
+++ b/.github/workflows/build.hugo.yml
@@ -45,4 +45,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ${{ steps.image.outputs.image}}
+          docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.luacheck.yml
+++ b/.github/workflows/build.luacheck.yml
@@ -45,4 +45,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ${{ steps.image.outputs.image}}
+          docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.markdownlint.yml
+++ b/.github/workflows/build.markdownlint.yml
@@ -45,4 +45,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ${{ steps.image.outputs.image}}
+          docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.netlify.yml
+++ b/.github/workflows/build.netlify.yml
@@ -45,4 +45,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ${{ steps.image.outputs.image}}
+          docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.pdf2htmlex.yml
+++ b/.github/workflows/build.pdf2htmlex.yml
@@ -43,4 +43,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ${{ steps.image.outputs.image}}
+          docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.pdftools.yml
+++ b/.github/workflows/build.pdftools.yml
@@ -45,4 +45,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ${{ steps.image.outputs.image}}
+          docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.psscriptanalyzer.yml
+++ b/.github/workflows/build.psscriptanalyzer.yml
@@ -46,4 +46,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ${{ steps.image.outputs.image}}
+          docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.pylint.yml
+++ b/.github/workflows/build.pylint.yml
@@ -45,4 +45,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ${{ steps.image.outputs.image}}
+          docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.rsvg.yml
+++ b/.github/workflows/build.rsvg.yml
@@ -45,4 +45,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ${{ steps.image.outputs.image}}
+          docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.rubocop.yml
+++ b/.github/workflows/build.rubocop.yml
@@ -45,4 +45,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ${{ steps.image.outputs.image}}
+          docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.shellcheck.yml
+++ b/.github/workflows/build.shellcheck.yml
@@ -45,4 +45,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ${{ steps.image.outputs.image}}
+          docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.stylelint.yml
+++ b/.github/workflows/build.stylelint.yml
@@ -45,4 +45,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ${{ steps.image.outputs.image}}
+          docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.surge.yml
+++ b/.github/workflows/build.surge.yml
@@ -45,4 +45,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ${{ steps.image.outputs.image}}
+          docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.svgtools.yml
+++ b/.github/workflows/build.svgtools.yml
@@ -45,4 +45,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ${{ steps.image.outputs.image}}
+          docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.tflint.yml
+++ b/.github/workflows/build.tflint.yml
@@ -45,4 +45,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ${{ steps.image.outputs.image}}
+          docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.wkhtmltopdf.yml
+++ b/.github/workflows/build.wkhtmltopdf.yml
@@ -45,4 +45,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ${{ steps.image.outputs.image}}
+          docker push --all-tags ${{ steps.image.outputs.image}}


### PR DESCRIPTION
Docker push is assuming the tag as `latest` when it should push all tags.

This switches all builds to now formally push all of the known tags.