### PR TITLE
docs(design): Flush out the designs

### DIFF
--- a/docs/www/designs/images-built-by-bazel.md
+++ b/docs/www/designs/images-built-by-bazel.md
@@ -1,0 +1,98 @@
+# Image built by Bazel
+
+## Abstract
+
+Images built with Dockerfiles have been using templating or layer-inefficient executions to better follow code-reuse standards. This has introduced more complexity and obfuscated the build harness. This design proposes leveraging bazel to build and test the docker images.
+
+_This is an adapted design from the repository cardboardci/bazel-docker-awscli_
+
+## Proposal
+
+This proposes the introduction of bazel as both the build harness, and the mechanism to build the docker images. This would leverage `rules_docker` to handle the construction of the images, and orchestrate the execution of tests. This was evaluated in the proof of concept `bazel-docker-awscli` which determined that the lack of windows support was the limiting factor. Recent developments in environments-as-code has made that issue no longer a problem.
+
+### Package Manager Rules
+
+For the package managers that would need rules, they would follow the format of the existing `download_pkgs` (`f(deps[]) => tarball`). Most of the package managers used in CardboardCI have some way to download but not install the packages. Here are some examples of the rule usages:
+
+```python
+download_npm(
+    name = "pkgs",
+    image_tar = "@ubuntu//image",
+    packages = [
+        "surge:0.0.1",
+    ],
+
+    # Could we read all of the packages from a file?
+    # packages_file = ":file"
+)
+```
+
+If the rule could support a way of providing a file, then the same automated process as now could be used for upgrading the dependencies. The big problem I see with this is that if only 1 dependency changes, we must re-download all of the other dependencies. The option of bazel-ifying each dependency as a rule would create problems with updating (e.g. how to update version). This isn't too bad if there exists a file like so:
+
+```python
+load("@io_bazel_rules_docker//docker/package_managers:download_npm.bzl", "download_npm")
+
+download_npm(
+    name = "pkg_surge",
+    image_tar = "@ubuntu//image",
+    src = ":surge.dep"
+)
+```
+
+With the `.dep` file looking something like this:
+
+```toml
+name="surge"
+version="0.0.1"
+```
+
+## Full Example
+
+An example of an image built with Bazel is included below:
+
+```starlark
+download_pkgs(
+    name = "apt_get_download",
+    image_tar = "//images/base:image.tar",
+    packages = ["awscli"],
+)
+
+install_pkgs(
+    name = "apt_get_installed",
+    image_tar = "//images/base:image.tar",
+    installables_tar = ":apt_get_download.tar",
+    installation_cleanup_commands = "rm -rf /var/lib/apt/lists/*",
+    output_image_name = "apt_get_installed",
+)
+
+cardboardci_image(
+    name = "image",
+    base = ":apt_get_installed.tar",
+    labels = {
+        "org.opencontainers.image.title": "awscli",
+        "org.opencontainers.image.summary": "AWS CLI",
+        "org.opencontainers.image.description": " The AWS Command Line Interface (CLI) is a unified tool to manage your AWS services",
+    },
+)
+
+cardboardci_test(
+    name = "test",
+    configs = [
+        "//images/awscli/test_configs:command.yaml",
+    ],
+    image = ":image",
+)
+
+```
+
+## Retrospective Advantages
+
+As the above is adapted from the existing proof of concept, the following are some notes made from the advantages of the bazel approach:
+
+-   Tests can be split off into root levels, and applied to all images
+-   Standards on metadata can be easily enforced for all images
+-   Common fields in labeling can be abstracted away with macros
+-   Base image can be built alongside existing images
+-   Caching has the potential to speed up the build process (or reduce re-builds)
+-   Sum verification of all dependencies can be strictly required
+-   Vendoring of the dependencies can be done through macros or additional rules

--- a/docs/www/designs/sum-verified-packages.md
+++ b/docs/www/designs/sum-verified-packages.md
@@ -1,11 +1,79 @@
 # Sum Verified Rules Investigation
 
-Below is an outline of the design idea for checking the integrity of all packages installed into the docker image, to ensure that the installed package is as expected. This is a design idea and not implemented into the code at this time.
+## Abstract
+
+Dependencies that are installed onto images built by Bazel are not sum verified. This design proposes a mechanism for in-bazel sum verification of dependencies based on the packages downloaded from the associated package managers.
+
+## Proposal
+
+This proposes the itnroduction of rules based on each type of package, that would declare the necessary parameter to download the package from its authoritative source. Each rule would be of the form `container_*_package`, that would at minimum ensure a `name`, `version` and `sum`. This rule would not be responsible for downloading the package itself, as to make it easier to vendor the dependencies into internal data stores. The responsibility of downloading and installing packages would be handled by other macros that would handle downloading and sum verification.
+
+An example of the rule can be seen for `lua` as such:
 
 ```starlark
 # Define a package file that is used for download/integrity checks
-container_luarocks_package(
-    name = "luarocks_luacheck",
+container_lua_package(
+    name = "lua_luacheck",
+    package = "luacheck",
+    version = "1.23.0",
+    sum = "4521794f0fba2e20f3bf15846ab5e01d5332e587e9ce81629c7f96c793bb7036",
+)
+```
+
+The `container_*_package` rule would yield an output file that is used by the `container_*_download` macro for downloading the packages from an authoritative source. This file is intended to be re-usable, so that it can be used to retrieve the dependencies internal data stores instead of the authoritative source.
+
+An example of the macro can be seen for `lua` as such:
+
+```starlark
+# This outputs a tar, csv and build script
+container_lua_download(
+    name = "lua_download",
+    image_tar = "//images/downloader:image.tar",
+    packages = [
+        ":lua_luacheck",
+        # other dependencies can be added here
+    ]
+)
+```
+
+When the download is completed, a tar file is available with all of the dependencies downloaded by the macro. Each dependency has its sum generated that placed into a package lock csv file. This CSV file is supplied to an internal verification rule to ensure the dependencies are as expected. The CSV file would be of the format: `package,file,version,sum`. This file would be supplied to the installation rule.
+
+### Verification
+
+Verification of the downloaded dependencies would be handled by `container_pkg_check`. This rule would be used internally by the `container_*_download` macros to assist with caching the downloaded files. Multiple package lock csv files can be provided to the rule, which allow checking sums for
+
+An example of the macro can be seen for `lua` as such:
+
+```starlark
+# This outputs a tar, csv and build script
+container_pkg_check(
+    name = "image_integrity",
+    tar = [
+        ":lua_download.csv",
+        ":npm_download.csv",
+        # A type of install that requires a custom `image_tar`
+        ":npm_special_download.csv",
+        # other package dependencies can be added here
+    ],
+    packages = [
+        ":lua_luacheck",
+        ":npm_bazel",
+        ":npm_specialdependency",
+        # other dependencies can be added here
+    ]
+)
+```
+
+Splitting verification into its own rule enables for it to be leveraged by custom/freeform mechanisms of retrieving dependencies outside of the common package managers. The retrieved files can be checked as long as the package lock csv file format is met.
+
+## Full Example
+
+Below is an outline of the design for checking the integrity of all packages installed into the docker image, to ensure that the installed package is as expected. This is a design idea and not implemented into the code at this time.
+
+```starlark
+# Define a package file that is used for download/integrity checks
+container_lua_package(
+    name = "lua_luacheck",
     package = "luacheck",
     version = "1.23.0",
     sum = "4521794f0fba2e20f3bf15846ab5e01d5332e587e9ce81629c7f96c793bb7036",
@@ -13,15 +81,15 @@ container_luarocks_package(
 
 # Download the luarock packages, with the necessary data to perform
 # integrity checks on the data. The output csv can be used with the
-# json sums to ensure integrity of the downloaded files. Failing on 
+# json sums to ensure integrity of the downloaded files. Failing on
 # an integrity check will just be a pain point
 #
 # This outputs a tar, csv and build script
-container_luarocks_download(
-    name = "luarocks_download",
+container_lua_download(
+    name = "lua_download",
     image_tar = "//images/downloader:image.tar",
     packages = [
-        ":luarocks_luacheck",
+        ":lua_luacheck",
         # other dependencies can be added here
     ]
 )
@@ -31,21 +99,21 @@ container_luarocks_download(
 container_package_integrity(
     name = "integrity",
     packages = [
-        ":luarocks_luacheck",
+        ":lua_luacheck",
         # ... and other json files
     ],
     results = [
-        ":luarocks_download.csv",
+        ":lua_download.csv",
     ]
 )
 
 # The tar file is then installed using the existing package manager
-container_luarocks_install(
-    name = "luarocks_installed",
+container_lua_install(
+    name = "lua_installed",
     image_tar = "//images/base:image.tar",
-    installables_tar = ":luarocks_download.tar",
+    installables_tar = ":lua_download.tar",
     installation_pre_commands = "",
     installation_post_commands = "",
-    output_image_name = "luarocks_installed",
+    output_image_name = "lua_installed",
 )
 ```

--- a/docs/www/designs/sum-verified-packages.md
+++ b/docs/www/designs/sum-verified-packages.md
@@ -6,7 +6,7 @@ Dependencies that are installed onto images built by Bazel are not sum verified.
 
 ## Proposal
 
-This proposes the itnroduction of rules based on each type of package, that would declare the necessary parameter to download the package from its authoritative source. Each rule would be of the form `container_*_package`, that would at minimum ensure a `name`, `version` and `sum`. This rule would not be responsible for downloading the package itself, as to make it easier to vendor the dependencies into internal data stores. The responsibility of downloading and installing packages would be handled by other macros that would handle downloading and sum verification.
+This proposes the introduction of rules based on each type of package, that would declare the necessary parameter to download the package from its authoritative source. Each rule would be of the form `container_*_package`, that would at minimum ensure a `name`, `version` and `sum`. This rule would not be responsible for downloading the package itself, as to make it easier to vendor the dependencies into internal data stores. The responsibility of downloading and installing packages would be handled by other macros that would handle downloading and sum verification.
 
 An example of the rule can be seen for `lua` as such:
 


### PR DESCRIPTION
The designs were lacking context, this flushes them out following a rough "design doc" style.

Flushes out the design documents to better cover the reasons for why, as well as bring in the design proof of concept to help flush out the design namespace.