### PR TITLE
fix(build): Text of base upgrader is incorrect

### DIFF
--- a/.github/workflows/upgrader.base.yml
+++ b/.github/workflows/upgrader.base.yml
@@ -63,6 +63,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CARDBOARDCI_PAT_TOKEN }}
         with:
           username: jrbeverly
-          title: "Bump base image to ${{ steps.tag.outputs.image-tag }} tag"
+          title: "deps(ubuntu): Bump base image to ${{ steps.tag.outputs.image-tag }} tag"
           body: "Bumps the base image to `${{ steps.tag.outputs.image-tag }}`.\n\nReplaces the old ubuntu image digest with the latest digest for tag `${{ steps.tag.outputs.image-tag }}`.\n - source-digest: `${{ steps.source.outputs.image-digest }}`\n - tag-digest: `${{ steps.digest.outputs.image-digest }}`"
           options: "--label dependencies"

--- a/.github/workflows/upgrader.base.yml
+++ b/.github/workflows/upgrader.base.yml
@@ -64,5 +64,5 @@ jobs:
         with:
           username: jrbeverly
           title: "Bump base image to ${{ steps.tag.outputs.image-tag }} tag"
-          body: "Bumps the base image to `${{ steps.tag.outputs.image-tag }}`.\n\nReplaces the old ubuntu image digest with the latest digest for tag `${{ steps.dockerhub.outputs.image-tag }}`.\n - source-digest: `${{ steps.source.outputs.image-digest }}`\n - tag-digest: `${{ steps.dockerhub.outputs.image-digest }}`"
+          body: "Bumps the base image to `${{ steps.tag.outputs.image-tag }}`.\n\nReplaces the old ubuntu image digest with the latest digest for tag `${{ steps.tag.outputs.image-tag }}`.\n - source-digest: `${{ steps.source.outputs.image-digest }}`\n - tag-digest: `${{ steps.digest.outputs.image-digest }}`"
           options: "--label dependencies"


### PR DESCRIPTION
Text of the base image upgrader is using invalid output references.

This causes empty text in the resultant pull request.