### PR TITLE
deps(ubuntu): Bump base image to focal-20210609 tag

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,7 +37,7 @@ rules_pkg_dependencies()
 
 container_pull(
     name = "ubuntu",
-    digest = "sha256:86ac87f73641c920fb42cc9612d4fb57b5626b56ea2a19b894d0673fd5b4f2e9",
+    digest = "sha256:376209074d481dca0a9cf4282710cd30a9e7ff402dea8261acdaaf57a18971dd",
     registry = "index.docker.io",
     repository = "library/ubuntu",
 )


### PR DESCRIPTION
Bumps the base image to `focal-20210609`.

Replaces the old ubuntu image digest with the latest digest for tag `focal-20210609`.
 - source-digest: `sha256:86ac87f73641c920fb42cc9612d4fb57b5626b56ea2a19b894d0673fd5b4f2e9`
 - tag-digest: `sha256:376209074d481dca0a9cf4282710cd30a9e7ff402dea8261acdaaf57a18971dd`