### PR TITLE
fix(build): Replace PAT with inline secrets

### DIFF
--- a/.github/workflows/build.awscli.yml
+++ b/.github/workflows/build.awscli.yml
@@ -41,8 +41,14 @@ jobs:
           docker tag bazel/images/awscli:image ${{ steps.image.outputs.fullname }}
           docker tag bazel/images/awscli:image ${{ steps.image.outputs.image }}:edge
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.base.yml
+++ b/.github/workflows/build.base.yml
@@ -38,8 +38,14 @@ jobs:
           docker tag bazel/images/base:image ${{ steps.image.outputs.fullname }}
           docker tag bazel/images/base:image ${{ steps.image.outputs.image }}:edge
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.bats.yml
+++ b/.github/workflows/build.bats.yml
@@ -41,8 +41,14 @@ jobs:
           docker tag bazel/images/bats:image ${{ steps.image.outputs.fullname }}
           docker tag bazel/images/bats:image ${{ steps.image.outputs.image }}:edge
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.cppcheck.yml
+++ b/.github/workflows/build.cppcheck.yml
@@ -41,8 +41,14 @@ jobs:
           docker tag bazel/images/cppcheck:image ${{ steps.image.outputs.fullname }}
           docker tag bazel/images/cppcheck:image ${{ steps.image.outputs.image }}:edge
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.dbxcli.yml
+++ b/.github/workflows/build.dbxcli.yml
@@ -41,8 +41,14 @@ jobs:
           docker tag bazel/images/dbxcli:image ${{ steps.image.outputs.fullname }}
           docker tag bazel/images/dbxcli:image ${{ steps.image.outputs.image }}:edge
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.ecr.yml
+++ b/.github/workflows/build.ecr.yml
@@ -41,8 +41,14 @@ jobs:
           docker tag bazel/images/ecr:image ${{ steps.image.outputs.fullname }}
           docker tag bazel/images/ecr:image ${{ steps.image.outputs.image }}:edge
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.github.yml
+++ b/.github/workflows/build.github.yml
@@ -41,8 +41,14 @@ jobs:
           docker tag bazel/images/github:image ${{ steps.image.outputs.fullname }}
           docker tag bazel/images/github:image ${{ steps.image.outputs.image }}:edge
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.gitlab.yml
+++ b/.github/workflows/build.gitlab.yml
@@ -41,8 +41,14 @@ jobs:
           docker tag bazel/images/gitlab:image ${{ steps.image.outputs.fullname }}
           docker tag bazel/images/gitlab:image ${{ steps.image.outputs.image }}:edge
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.hadolint.yml
+++ b/.github/workflows/build.hadolint.yml
@@ -41,8 +41,14 @@ jobs:
           docker tag bazel/images/hadolint:image ${{ steps.image.outputs.fullname }}
           docker tag bazel/images/hadolint:image ${{ steps.image.outputs.image }}:edge
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.htmlhint.yml
+++ b/.github/workflows/build.htmlhint.yml
@@ -41,8 +41,14 @@ jobs:
           docker tag bazel/images/htmlhint:image ${{ steps.image.outputs.fullname }}
           docker tag bazel/images/htmlhint:image ${{ steps.image.outputs.image }}:edge
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.hugo.yml
+++ b/.github/workflows/build.hugo.yml
@@ -41,8 +41,14 @@ jobs:
           docker tag bazel/images/hugo:image ${{ steps.image.outputs.fullname }}
           docker tag bazel/images/hugo:image ${{ steps.image.outputs.image }}:edge
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.luacheck.yml
+++ b/.github/workflows/build.luacheck.yml
@@ -41,8 +41,14 @@ jobs:
           docker tag bazel/images/luacheck:image ${{ steps.image.outputs.fullname }}
           docker tag bazel/images/luacheck:image ${{ steps.image.outputs.image }}:edge
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.markdownlint.yml
+++ b/.github/workflows/build.markdownlint.yml
@@ -41,8 +41,14 @@ jobs:
           docker tag bazel/images/markdownlint:image ${{ steps.image.outputs.fullname }}
           docker tag bazel/images/markdownlint:image ${{ steps.image.outputs.image }}:edge
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.netlify.yml
+++ b/.github/workflows/build.netlify.yml
@@ -41,8 +41,14 @@ jobs:
           docker tag bazel/images/netlify:image ${{ steps.image.outputs.fullname }}
           docker tag bazel/images/netlify:image ${{ steps.image.outputs.image }}:edge
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.pdf2htmlex.yml
+++ b/.github/workflows/build.pdf2htmlex.yml
@@ -39,8 +39,14 @@ jobs:
           docker tag bazel/images/pdf2htmlex:image ${{ steps.image.outputs.fullname }}
           docker tag bazel/images/pdf2htmlex:image ${{ steps.image.outputs.image }}:edge
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.pdftools.yml
+++ b/.github/workflows/build.pdftools.yml
@@ -41,8 +41,14 @@ jobs:
           docker tag bazel/images/pdftools:image ${{ steps.image.outputs.fullname }}
           docker tag bazel/images/pdftools:image ${{ steps.image.outputs.image }}:edge
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.psscriptanalyzer.yml
+++ b/.github/workflows/build.psscriptanalyzer.yml
@@ -42,8 +42,14 @@ jobs:
           docker tag bazel/images/psscriptanalyzer:image ${{ steps.image.outputs.fullname }}
           docker tag bazel/images/psscriptanalyzer:image ${{ steps.image.outputs.image }}:edge
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.pylint.yml
+++ b/.github/workflows/build.pylint.yml
@@ -41,8 +41,14 @@ jobs:
           docker tag bazel/images/pylint:image ${{ steps.image.outputs.fullname }}
           docker tag bazel/images/pylint:image ${{ steps.image.outputs.image }}:edge
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.rsvg.yml
+++ b/.github/workflows/build.rsvg.yml
@@ -41,8 +41,14 @@ jobs:
           docker tag bazel/images/rsvg:image ${{ steps.image.outputs.fullname }}
           docker tag bazel/images/rsvg:image ${{ steps.image.outputs.image }}:edge
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.rubocop.yml
+++ b/.github/workflows/build.rubocop.yml
@@ -41,8 +41,14 @@ jobs:
           docker tag bazel/images/rubocop:image ${{ steps.image.outputs.fullname }}
           docker tag bazel/images/rubocop:image ${{ steps.image.outputs.image }}:edge
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.shellcheck.yml
+++ b/.github/workflows/build.shellcheck.yml
@@ -41,8 +41,14 @@ jobs:
           docker tag bazel/images/shellcheck:image ${{ steps.image.outputs.fullname }}
           docker tag bazel/images/shellcheck:image ${{ steps.image.outputs.image }}:edge
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.stylelint.yml
+++ b/.github/workflows/build.stylelint.yml
@@ -41,8 +41,14 @@ jobs:
           docker tag bazel/images/stylelint:image ${{ steps.image.outputs.fullname }}
           docker tag bazel/images/stylelint:image ${{ steps.image.outputs.image }}:edge
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.surge.yml
+++ b/.github/workflows/build.surge.yml
@@ -41,8 +41,14 @@ jobs:
           docker tag bazel/images/surge:image ${{ steps.image.outputs.fullname }}
           docker tag bazel/images/surge:image ${{ steps.image.outputs.image }}:edge
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.svgtools.yml
+++ b/.github/workflows/build.svgtools.yml
@@ -41,8 +41,14 @@ jobs:
           docker tag bazel/images/svgtools:image ${{ steps.image.outputs.fullname }}
           docker tag bazel/images/svgtools:image ${{ steps.image.outputs.image }}:edge
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.tflint.yml
+++ b/.github/workflows/build.tflint.yml
@@ -41,8 +41,14 @@ jobs:
           docker tag bazel/images/tflint:image ${{ steps.image.outputs.fullname }}
           docker tag bazel/images/tflint:image ${{ steps.image.outputs.image }}:edge
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/build.wkhtmltopdf.yml
+++ b/.github/workflows/build.wkhtmltopdf.yml
@@ -41,8 +41,14 @@ jobs:
           docker tag bazel/images/wkhtmltopdf:image ${{ steps.image.outputs.fullname }}
           docker tag bazel/images/wkhtmltopdf:image ${{ steps.image.outputs.image }}:edge
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'
         run: |
-          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
           docker push --all-tags ${{ steps.image.outputs.image}}

--- a/.github/workflows/upgrader.base.yml
+++ b/.github/workflows/upgrader.base.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.GHCR_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install buildozer
         run: |
           curl -sSL https://github.com/bazelbuild/buildtools/releases/download/3.5.0/buildozer > buildozer
@@ -47,7 +47,7 @@ jobs:
           username: jrbeverly
           email: jonathan@jrbeverly.me
           branch: "base-image-to-${{ steps.tag.outputs.image-tag }}"
-          token: ${{ secrets.GHCR_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Buildozer to edit digest
         if: ${{ steps.digest.outputs.image-digest != steps.source.outputs.image-digest }}
         run: |
@@ -60,7 +60,7 @@ jobs:
         uses: ./.github/actions/git-commit
         if: ${{ steps.digest.outputs.image-digest != steps.source.outputs.image-digest && github.ref == 'refs/heads/main' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.CARDBOARDCI_PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           username: jrbeverly
           title: "deps(ubuntu): Bump base image to ${{ steps.tag.outputs.image-tag }} tag"


### PR DESCRIPTION
Replace the PAT for the build process with the GITHUB_TOKEN available on runners